### PR TITLE
[Feat] user_profile, favorite 도메인 Entity / Repository 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/favorite/entity/FavoriteStoreBrand.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/entity/FavoriteStoreBrand.java
@@ -2,6 +2,7 @@ package com.umc.barkit.domain.favorite.entity;
 
 import com.umc.barkit.domain.favorite.enums.FavoriteStoreStatus;
 import com.umc.barkit.domain.member.entity.User;
+import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -22,15 +23,31 @@ public class FavoriteStoreBrand extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    /* ===== User 연관 ===== */
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // store는 다른 분이 구현
+    /* ===== StoreBrand FK (쓰기 책임) ===== */
     @Column(name = "store_brand_id", nullable = false)
     private Long storeBrandId;
 
+    /* ===== StoreBrand 객체 탐색용 (읽기 전용) ===== */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(
+            name = "store_brand_id",
+            insertable = false,
+            updatable = false
+    )
+    private StoreBrand storeBrand;
+
+    /* ===== 상태 ===== */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private FavoriteStoreStatus status = FavoriteStoreStatus.ACTIVE;
+
+    /* ===== 도메인 로직 ===== */
+    public void delete() {
+        this.status = FavoriteStoreStatus.DELETED;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/favorite/entity/FavoriteStoreBrand.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/entity/FavoriteStoreBrand.java
@@ -1,0 +1,36 @@
+package com.umc.barkit.domain.favorite.entity;
+
+import com.umc.barkit.domain.favorite.enums.FavoriteStoreStatus;
+import com.umc.barkit.domain.member.entity.User;
+import com.umc.barkit.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(
+        name = "favorite_store_brand",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "store_brand_id"})
+        }
+)
+public class FavoriteStoreBrand extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // store는 다른 분이 구현
+    @Column(name = "store_brand_id", nullable = false)
+    private Long storeBrandId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FavoriteStoreStatus status = FavoriteStoreStatus.ACTIVE;
+}

--- a/src/main/java/com/umc/barkit/domain/favorite/enums/FavoriteStoreStatus.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/enums/FavoriteStoreStatus.java
@@ -1,0 +1,6 @@
+package com.umc.barkit.domain.favorite.enums;
+
+public enum FavoriteStoreStatus {
+    ACTIVE,
+    DELETED
+}

--- a/src/main/java/com/umc/barkit/domain/favorite/repository/FavoriteStoreBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/repository/FavoriteStoreBrandRepository.java
@@ -1,0 +1,10 @@
+package com.umc.barkit.domain.favorite.repository;
+
+import com.umc.barkit.domain.favorite.entity.FavoriteStoreBrand;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FavoriteStoreBrandRepository
+        extends JpaRepository<FavoriteStoreBrand, Long> {
+}

--- a/src/main/java/com/umc/barkit/domain/profile/entity/UserProfile.java
+++ b/src/main/java/com/umc/barkit/domain/profile/entity/UserProfile.java
@@ -1,0 +1,39 @@
+package com.umc.barkit.domain.profile.entity;
+
+import com.umc.barkit.domain.member.entity.User;
+import com.umc.barkit.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(
+        name = "user_profile",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = "user_id")
+        }
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class UserProfile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /**
+     * User 와 1:1 관계
+     * - user가 주 엔티티
+     * - profile은 확장 정보
+     */
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "profile_image_url", length = 255)
+    private String profileImageUrl;
+
+    @Column(name = "bio", length = 255)
+    private String bio;
+}

--- a/src/main/java/com/umc/barkit/domain/profile/repository/UserProfileRepository.java
+++ b/src/main/java/com/umc/barkit/domain/profile/repository/UserProfileRepository.java
@@ -1,0 +1,15 @@
+package com.umc.barkit.domain.profile.repository;
+
+import com.umc.barkit.domain.profile.entity.UserProfile;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserProfileRepository extends JpaRepository<UserProfile, Long> {
+
+    Optional<UserProfile> findByUserId(Long userId);
+
+    boolean existsByUserId(Long userId);
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
Favorite 및 UserProfile 도메인 Entity / Repository 구현

## 🛠️ 작업 상세 내용
- [x] FavoriteStoreBrand Entity, Repository 생성
- [x] FavoriteStoreStatus(enum) 추가
- [x] UserProfile Entity, Repository 생성
- [x] User ↔ UserProfile 1:1 단방향 연관관계 설정
- [x] FavoriteStoreBrand soft delete 처리를 위한 status 필드 및 delete() 도메인 메서드 추가
- [x] store_brand_id FK 기반 StoreBrand 읽기 전용 연관관계 매핑 추가 (insertable=false, updatable=false)

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)