### PR TITLE
feat: Favorite 도메인 CRUD API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/controller/FavoriteController.java
@@ -23,7 +23,7 @@ public class FavoriteController {
     public ApiResponse<List<FavoriteResponse>> getFavorites(
             @RequestHeader("Authorization") String token
     ) {
-        Long userId = 1L; // TODO: JWT에서 추출
+        Long userId = 100L; // TODO: JWT에서 추출
 
         List<FavoriteStoreBrand> favorites = favoriteService.getFavorites(userId);
         List<FavoriteResponse> result = favorites.stream()
@@ -39,7 +39,7 @@ public class FavoriteController {
             @RequestHeader("Authorization") String token,
             @RequestBody FavoriteCreateRequest request
     ) {
-        Long userId = 1L; // TODO: JWT에서 추출
+        Long userId = 100L; // TODO: JWT에서 추출
 
         favoriteService.createFavorite(userId, request.getStoreBrandId());
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
@@ -51,7 +51,7 @@ public class FavoriteController {
             @RequestHeader("Authorization") String token,
             @PathVariable Long favoriteId
     ) {
-        Long userId = 1L; // TODO: JWT에서 추출
+        Long userId = 100L; // TODO: JWT에서 추출
 
         favoriteService.deleteFavorite(userId, favoriteId);
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);

--- a/src/main/java/com/umc/barkit/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/controller/FavoriteController.java
@@ -1,0 +1,59 @@
+package com.umc.barkit.domain.favorite.controller;
+
+import com.umc.barkit.domain.favorite.dto.request.FavoriteCreateRequest;
+import com.umc.barkit.domain.favorite.dto.response.FavoriteResponse;
+import com.umc.barkit.domain.favorite.entity.FavoriteStoreBrand;
+import com.umc.barkit.domain.favorite.service.FavoriteService;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/favorites")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    // 즐겨찾기 조회 (최대 5개)
+    @GetMapping
+    public ApiResponse<List<FavoriteResponse>> getFavorites(
+            @RequestHeader("Authorization") String token
+    ) {
+        Long userId = 1L; // TODO: JWT에서 추출
+
+        List<FavoriteStoreBrand> favorites = favoriteService.getFavorites(userId);
+        List<FavoriteResponse> result = favorites.stream()
+                .map(FavoriteResponse::from)
+                .toList();
+
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
+    }
+
+    // 즐겨찾기 추가
+    @PostMapping
+    public ApiResponse<Void> createFavorite(
+            @RequestHeader("Authorization") String token,
+            @RequestBody FavoriteCreateRequest request
+    ) {
+        Long userId = 1L; // TODO: JWT에서 추출
+
+        favoriteService.createFavorite(userId, request.getStoreBrandId());
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
+    }
+
+    // 즐겨찾기 삭제
+    @DeleteMapping("/{favoriteId}")
+    public ApiResponse<Void> deleteFavorite(
+            @RequestHeader("Authorization") String token,
+            @PathVariable Long favoriteId
+    ) {
+        Long userId = 1L; // TODO: JWT에서 추출
+
+        favoriteService.deleteFavorite(userId, favoriteId);
+        return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/favorite/dto/request/FavoriteCreateRequest.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/dto/request/FavoriteCreateRequest.java
@@ -1,0 +1,11 @@
+package com.umc.barkit.domain.favorite.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class FavoriteCreateRequest {
+
+    @NotNull(message = "storeBrandId는 필수입니다.")
+    private Long storeBrandId;
+}

--- a/src/main/java/com/umc/barkit/domain/favorite/dto/response/FavoriteResponse.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/dto/response/FavoriteResponse.java
@@ -1,0 +1,26 @@
+package com.umc.barkit.domain.favorite.dto.response;
+
+import com.umc.barkit.domain.favorite.entity.FavoriteStoreBrand;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FavoriteResponse {
+
+    private Long favoriteId;
+    private Long storeBrandId;
+    private String storeBrandName;
+
+    public static FavoriteResponse from(FavoriteStoreBrand favorite) {
+        return FavoriteResponse.builder()
+                .favoriteId(favorite.getId())
+                .storeBrandId(favorite.getStoreBrandId())
+                .storeBrandName(
+                        favorite.getStoreBrand() != null
+                                ? favorite.getStoreBrand().getName()
+                                : ""
+                )
+                .build();
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/favorite/entity/FavoriteStoreBrand.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/entity/FavoriteStoreBrand.java
@@ -5,12 +5,13 @@ import com.umc.barkit.domain.user.entity.User;
 import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.global.entity.BaseEntity;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Table(
         name = "favorite_store_brand",
         uniqueConstraints = {
@@ -48,7 +49,16 @@ public class FavoriteStoreBrand extends BaseEntity {
     /* ===== 상태 ===== */
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private FavoriteStoreStatus status = FavoriteStoreStatus.ACTIVE;
+    private FavoriteStoreStatus status;
+
+    /* ===== 생성 로직 ===== */
+    public static FavoriteStoreBrand create(User user, Long storeBrandId) {
+        return FavoriteStoreBrand.builder()
+                .user(user)
+                .storeBrandId(storeBrandId)
+                .status(FavoriteStoreStatus.ACTIVE)
+                .build();
+    }
 
     /* ===== 도메인 로직 ===== */
     public void delete() {

--- a/src/main/java/com/umc/barkit/domain/favorite/exception/code/FavoriteErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/exception/code/FavoriteErrorCode.java
@@ -1,0 +1,40 @@
+package com.umc.barkit.domain.favorite.exception.code;
+
+import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum FavoriteErrorCode implements BaseErrorCode {
+
+    // ===== Favorite =====
+    FAVORITE_ALREADY_EXISTS(
+            HttpStatus.BAD_REQUEST,
+            "FAVORITE4001",
+            "이미 즐겨찾기한 매장입니다."
+    ),
+
+    FAVORITE_NOT_FOUND(
+            HttpStatus.NOT_FOUND,
+            "FAVORITE4002",
+            "즐겨찾기 정보를 찾을 수 없습니다."
+    ),
+
+    FAVORITE_LIMIT_EXCEEDED(
+            HttpStatus.BAD_REQUEST,
+            "FAVORITE4003",
+            "즐겨찾기는 최대 5개까지 가능합니다."
+    ),
+
+    FAVORITE_FORBIDDEN(
+            HttpStatus.FORBIDDEN,
+            "FAVORITE4004",
+            "해당 즐겨찾기에 대한 권한이 없습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/barkit/domain/favorite/repository/FavoriteStoreBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/repository/FavoriteStoreBrandRepository.java
@@ -1,10 +1,32 @@
 package com.umc.barkit.domain.favorite.repository;
 
 import com.umc.barkit.domain.favorite.entity.FavoriteStoreBrand;
+import com.umc.barkit.domain.favorite.enums.FavoriteStoreStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
-public interface FavoriteStoreBrandRepository
-        extends JpaRepository<FavoriteStoreBrand, Long> {
+public interface FavoriteStoreBrandRepository extends JpaRepository<FavoriteStoreBrand, Long> {
+
+    // 로그인 유저 기준 ACTIVE 즐겨찾기 최신 5개
+    List<FavoriteStoreBrand> findTop5ByUser_IdAndStatusOrderByCreatedAtDesc(
+            Long userId,
+            FavoriteStoreStatus status
+    );
+
+    // 중복 즐겨찾기 방지 (ACTIVE 기준)
+    boolean existsByUser_IdAndStoreBrandIdAndStatus(
+            Long userId,
+            Long storeBrandId,
+            FavoriteStoreStatus status
+    );
+
+    // 삭제/조회 권한 체크
+    Optional<FavoriteStoreBrand> findByIdAndUser_Id(Long id, Long userId);
+
+    // (선택) 즐겨찾기 5개 제한 체크용
+    long countByUser_IdAndStatus(Long userId, FavoriteStoreStatus status);
 }

--- a/src/main/java/com/umc/barkit/domain/favorite/service/FavoriteService.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/service/FavoriteService.java
@@ -1,0 +1,74 @@
+package com.umc.barkit.domain.favorite.service;
+
+import com.umc.barkit.domain.favorite.entity.FavoriteStoreBrand;
+import com.umc.barkit.domain.favorite.enums.FavoriteStoreStatus;
+import com.umc.barkit.domain.favorite.exception.code.FavoriteErrorCode;
+import com.umc.barkit.domain.favorite.repository.FavoriteStoreBrandRepository;
+import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.repository.UserRepository;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FavoriteService {
+
+    private final FavoriteStoreBrandRepository favoriteRepository;
+    private final UserRepository userRepository;
+
+    /* 즐겨찾기 목록 조회 (최대 5개) */
+    public List<FavoriteStoreBrand> getFavorites(Long userId) {
+        return favoriteRepository.findTop5ByUser_IdAndStatusOrderByCreatedAtDesc(
+                userId,
+                FavoriteStoreStatus.ACTIVE
+        );
+    }
+
+    /* 즐겨찾기 추가 */
+    @Transactional
+    public void createFavorite(Long userId, Long storeBrandId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(FavoriteErrorCode.FAVORITE_FORBIDDEN));
+
+        // 최대 5개 제한
+        long count = favoriteRepository.countByUser_IdAndStatus(
+                userId,
+                FavoriteStoreStatus.ACTIVE
+        );
+        if (count >= 5) {
+            throw new GeneralException(FavoriteErrorCode.FAVORITE_LIMIT_EXCEEDED);
+        }
+
+        // 중복 방지
+        boolean exists = favoriteRepository.existsByUser_IdAndStoreBrandIdAndStatus(
+                userId,
+                storeBrandId,
+                FavoriteStoreStatus.ACTIVE
+        );
+        if (exists) {
+            throw new GeneralException(FavoriteErrorCode.FAVORITE_ALREADY_EXISTS);
+        }
+
+        FavoriteStoreBrand favorite = FavoriteStoreBrand.create(user, storeBrandId);
+        favoriteRepository.save(favorite);
+    }
+
+    /* 즐겨찾기 삭제 (Soft Delete) */
+    @Transactional
+    public void deleteFavorite(Long userId, Long favoriteId) {
+
+        FavoriteStoreBrand favorite = favoriteRepository.findByIdAndUser_Id(
+                        favoriteId,
+                        userId
+                )
+                .orElseThrow(() -> new GeneralException(FavoriteErrorCode.FAVORITE_NOT_FOUND));
+
+        favorite.delete();
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
홈 화면에서 사용자가 즐겨찾기한 매장을 조회, 추가, 삭제할 수 있도록  Favorite 도메인의 기본 CRUD API를 구현했습니다.


## 🛠️ 작업 상세 내용
- [x] 즐겨찾기 목록 조회 API 구현 (GET /api/favorites)
- [x] 즐겨찾기 추가 API 구현 (POST /api/favorites)
- [x] 즐겨찾기 삭제 API 구현 (DELETE /api/favorites/{favoriteId})
- [x] 로그인 사용자 기준 필터링 적용
- [x] 즐겨찾기 최대 5개 제한 로직 적용
- [x] 중복 즐겨찾기 방지 로직 적용

## 🌱 참고 사항
- FavoriteStoreBrand 엔티티 기반으로 구현
- status = ACTIVE / DELETED 기반 Soft Delete 사용
- JWT 연동 전 단계로 Controller에서 임시 userId 사용 (TODO 주석 있)
- 홈 대시보드 API와 분리된 단독 CRUD 단계

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)