### PR TITLE
✨ [feat] 회원가입(약관 조회/이메일 중복확인/가입) API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 
 	// S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/barkit/domain/user/controller/TermController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/TermController.java
@@ -1,0 +1,36 @@
+package com.umc.barkit.domain.user.controller;
+
+import com.umc.barkit.domain.user.dto.res.TermResponseDto;
+import com.umc.barkit.domain.user.dto.res.TermResponseDto.TermListResponse;
+import com.umc.barkit.domain.user.exception.code.TermSuccessCode;
+import com.umc.barkit.domain.user.service.query.TermQueryService;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TermController {
+
+    private final TermQueryService termQueryService;
+
+    // 약관 목록 조회 API
+    @Operation(
+            summary = "약관 목록 조회 API",
+            description = "3개의 약관 데이터를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
+    })
+    @GetMapping("/api/terms")
+    public ApiResponse<TermResponseDto.TermListResponse> getTerms(){
+        TermListResponse terms = termQueryService.getTerms();
+        return ApiResponse.onSuccess(TermSuccessCode.TERM_LIST_OK, terms);
+
+    }
+
+}

--- a/src/main/java/com/umc/barkit/domain/user/controller/TermControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/TermControllerDocs.java
@@ -1,0 +1,20 @@
+package com.umc.barkit.domain.user.controller;
+
+import com.umc.barkit.domain.user.dto.res.TermResponseDto;
+import com.umc.barkit.domain.user.dto.res.TermResponseDto.TermListResponse;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public interface TermControllerDocs {
+
+    @Operation(
+            summary = "약관 목록 조회 API",
+            description = "3개의 약관 데이터를 조회합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
+    })
+    ApiResponse<TermListResponse> getTerms();
+}

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -1,0 +1,40 @@
+package com.umc.barkit.domain.user.controller;
+
+import com.umc.barkit.domain.user.dto.req.UserRequestDto;
+import com.umc.barkit.domain.user.dto.req.UserRequestDto.EmailCheckRequestDto;
+import com.umc.barkit.domain.user.dto.res.UserResponseDto;
+import com.umc.barkit.domain.user.exception.code.UserSuccessCode;
+import com.umc.barkit.domain.user.service.command.UserCommandService;
+import com.umc.barkit.domain.user.service.query.UserQueryService;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class UserController implements UserControllerDocs{
+
+    private final UserQueryService userQueryService;
+    private final UserCommandService userCommandService;
+
+    // 아이디(이메일) 중복 확인 API
+    @PostMapping("/auth/check-email")
+    public ApiResponse<UserResponseDto.EmailCheckResponseDto> checkEmail(@RequestBody @Valid EmailCheckRequestDto emailDto){
+        UserResponseDto.EmailCheckResponseDto response = userQueryService.checkEmailAvailability(emailDto.email());
+        return ApiResponse.onSuccess(UserSuccessCode.EMAIL_CHECK_OK, response);
+    }
+
+    // 회원가입 API
+    @PostMapping("/auth/signup")
+    public ApiResponse<UserResponseDto.SignupResponseDto> signup(@RequestBody @Valid UserRequestDto.SignupRequestDto signupRequestDto) {
+        UserResponseDto.SignupResponseDto response = userCommandService.Signup(signupRequestDto);
+        return ApiResponse.onSuccess(UserSuccessCode.CREATED, response);
+    }
+
+
+}

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -1,0 +1,32 @@
+package com.umc.barkit.domain.user.controller;
+
+import com.umc.barkit.domain.user.dto.req.UserRequestDto;
+import com.umc.barkit.domain.user.dto.res.UserResponseDto;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+public interface UserControllerDocs {
+
+    @Operation(
+            summary = "아이디(이메일) 중복 확인 API",
+            description = "이메일을 입력받아 해당 이메일의 사용 가능 여부를 확인합니다. 사용 가능한 이메일이면 true, 사용 불가능한 이메일이면 false를 메시지와 함께 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
+    })
+    ApiResponse<UserResponseDto.EmailCheckResponseDto> checkEmail(UserRequestDto.EmailCheckRequestDto emailDto);
+
+
+    @Operation(
+            summary = "회원가입 API",
+            description = "사용자가 입력한 정보를 통해 새로운 회원을 등록합니다. 이메일, 비밀번호, 이름 등을 받아 회원가입을 진행하며, 성공하면 회원가입 완료된 사용자 정보를 반환합니다. \n" +
+                    "회원가입 시, 3개의 약관에 대한 동의 여부 리스트를 반드시 포함해야 하며, 각 약관에 대해 사용자가 동의했는지 여부를 표시해야 합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
+    })
+    ApiResponse<UserResponseDto.SignupResponseDto> signup(UserRequestDto.SignupRequestDto signupRequestDto);
+}

--- a/src/main/java/com/umc/barkit/domain/user/converter/TermConverter.java
+++ b/src/main/java/com/umc/barkit/domain/user/converter/TermConverter.java
@@ -1,0 +1,28 @@
+package com.umc.barkit.domain.user.converter;
+
+import com.umc.barkit.domain.user.dto.res.TermResponseDto;
+import com.umc.barkit.domain.user.dto.res.TermResponseDto.TermItem;
+import com.umc.barkit.domain.user.entity.Term;
+import java.util.List;
+
+public class TermConverter {
+
+    // Entity -> DTO
+    public static TermResponseDto.TermItem toItem(Term term) {
+        return new TermResponseDto.TermItem(
+                term.getId(),
+                term.getContent(),
+                term.getIsRequired()
+        );
+    }
+
+
+    // Entity -> DTO
+    public static TermResponseDto.TermListResponse toListResponse(List<Term> terms) {
+        List<TermItem> items = terms.stream()
+                .map(TermConverter::toItem)
+                .toList();
+
+        return new TermResponseDto.TermListResponse(items);
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
@@ -1,0 +1,45 @@
+package com.umc.barkit.domain.user.converter;
+
+import com.umc.barkit.domain.user.dto.req.UserRequestDto;
+import com.umc.barkit.domain.user.entity.Term;
+import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.entity.mapping.UserTerm;
+import com.umc.barkit.domain.user.enums.UserStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class UserConverter {
+
+    // SignupRequestDto -> User Entity
+    public static User toUser(
+            UserRequestDto.SignupRequestDto dto,
+            String passwordHash
+    ){
+        return User.builder()
+                .name(dto.name())
+                .email(dto.email())
+                .passwordHash(passwordHash)
+                .phoneNumber(null)
+                .birthDate(null)
+                .status(UserStatus.ACTIVE) // 초기 상태는 ACTIVE
+                .deletedAt(null) // 삭제 시간은 null
+                .build();
+    }
+
+    // TermAgreement DTO -> UserTerm Entity
+    public static List<UserTerm> toUserTermEntities(List<UserRequestDto.TermAgreement> termAgreements, User user,
+                                                    List<Term> terms) {
+        LocalDateTime agreedAt = LocalDateTime.now(); // 현재 시간
+
+        return termAgreements.stream()
+                .map(agreement -> {
+                    Term term = terms.stream()
+                            .filter(t -> t.getId().equals(agreement.termId())) // TermId로 Term 찾기
+                            .findFirst()
+                            .orElseThrow(() -> new IllegalArgumentException("Invalid term ID"));
+
+                    return UserTerm.agree(user, term, agreedAt); // UserTerm 엔티티 생성
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -1,0 +1,35 @@
+package com.umc.barkit.domain.user.dto.req;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public class UserRequestDto {
+    public record EmailCheckRequestDto(
+            @NotBlank
+            String email
+    ){
+    }
+
+    public record SignupRequestDto(
+            @NotBlank
+            String name,
+            @Email @NotBlank
+            String email,
+            @NotBlank
+            String password,
+            @NotBlank
+            String confirmPassword,
+            @NotEmpty
+            @Valid
+            List<TermAgreement> terms
+    ){}
+
+    public record TermAgreement(
+            @NotNull Long termId,
+            @NotNull boolean isAgreed
+    ){}
+}

--- a/src/main/java/com/umc/barkit/domain/user/dto/res/TermResponseDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/res/TermResponseDto.java
@@ -1,0 +1,15 @@
+package com.umc.barkit.domain.user.dto.res;
+
+import java.util.List;
+
+public class TermResponseDto {
+    public record TermItem(
+            Long termId,
+            String content,
+            Boolean isRequired
+    ){}
+
+    public record TermListResponse(
+            List<TermItem> terms
+    ){}
+}

--- a/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
@@ -1,0 +1,14 @@
+package com.umc.barkit.domain.user.dto.res;
+
+public class UserResponseDto {
+
+    public record EmailCheckResponseDto(
+            boolean isAvailable,
+            String message
+    ){}
+
+    public record SignupResponseDto(
+            Long userId,
+            String email
+    ){}
+}

--- a/src/main/java/com/umc/barkit/domain/user/exception/TermException.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/TermException.java
@@ -1,0 +1,10 @@
+package com.umc.barkit.domain.user.exception;
+
+import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
+
+public class TermException extends GeneralException {
+    public TermException(BaseErrorCode code){
+        super(code);
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/user/exception/UserException.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/UserException.java
@@ -1,0 +1,10 @@
+package com.umc.barkit.domain.user.exception;
+
+import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
+
+public class UserException extends GeneralException {
+    public UserException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/TermSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/TermSuccessCode.java
@@ -1,0 +1,19 @@
+package com.umc.barkit.domain.user.exception.code;
+
+import com.umc.barkit.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TermSuccessCode implements BaseSuccessCode {
+
+    TERM_LIST_OK(HttpStatus.OK,
+            "TERM2000",
+            "약관 목록 조회에 성공했습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
@@ -1,0 +1,18 @@
+package com.umc.barkit.domain.user.exception.code;
+
+import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseErrorCode {
+
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH4004", "이미 사용 중인 아이디입니다."),
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH4003", "비밀번호 확인이 일치하지 않습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
@@ -1,0 +1,18 @@
+package com.umc.barkit.domain.user.exception.code;
+
+import com.umc.barkit.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum UserSuccessCode implements BaseSuccessCode {
+
+    EMAIL_CHECK_OK(HttpStatus.OK, "AUTH2000", "아이디 중복 확인에 성공했습니다."),
+    CREATED(HttpStatus.CREATED, "AUTH2001", "회원가입이 성공적으로 완료되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/umc/barkit/domain/user/repository/TermRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/TermRepository.java
@@ -1,9 +1,23 @@
 package com.umc.barkit.domain.user.repository;
 
 import com.umc.barkit.domain.user.entity.Term;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
+
+    // 활성화된 약관만 가져오되, 같은 약관이 여러 버전이면 최신 버전 가져오기
+    @Query("""
+        select t from Term t
+        where t.isActive = true
+          and t.version = (
+              select max(t2.version) from Term t2
+              where t2.code = t.code and t2.isActive = true
+          )
+        order by t.isRequired desc, t.id asc
+    """)
+    List<Term> findActiveLatestTerms();
 }

--- a/src/main/java/com/umc/barkit/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/UserRepository.java
@@ -6,4 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    boolean existsByEmail(String email);  // 아이디(이메일) 중복 확인
 }

--- a/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
@@ -1,0 +1,58 @@
+package com.umc.barkit.domain.user.service.command;
+
+import com.umc.barkit.domain.user.converter.UserConverter;
+import com.umc.barkit.domain.user.dto.req.UserRequestDto;
+import com.umc.barkit.domain.user.dto.res.UserResponseDto;
+import com.umc.barkit.domain.user.entity.Term;
+import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.entity.mapping.UserTerm;
+import com.umc.barkit.domain.user.repository.TermRepository;
+import com.umc.barkit.domain.user.repository.UserRepository;
+import com.umc.barkit.domain.user.repository.UserTermRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandService {
+
+    private final TermRepository termRepository;
+    private final UserRepository userRepository;
+    private final UserTermRepository userTermRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    // 회원가입
+    public UserResponseDto.SignupResponseDto Signup(UserRequestDto.SignupRequestDto signupRequestDto){
+
+        // 이메일 중복 확인
+        if (userRepository.existsByEmail(signupRequestDto.email())) {
+            throw new IllegalArgumentException("이미 등록된 이메일입니다");
+        }
+
+        // 비밀번호 확인
+        if(!signupRequestDto.password().equals(signupRequestDto.confirmPassword())){
+            throw new IllegalArgumentException("비밀번호와 비밀번호 확인이 일치하지 않습니다");
+        }
+
+        // 비밀번호 암호화
+        String encodedPassword = passwordEncoder.encode(signupRequestDto.password());
+
+        // User 생성
+        User user = UserConverter.toUser(signupRequestDto, encodedPassword);
+
+        // User 저장
+        userRepository.save(user);
+
+        // Term 리스트 조회
+        List<Term> terms = termRepository.findAll();
+
+        // UserTerm 생성
+        List<UserTerm> userTerms = UserConverter.toUserTermEntities(signupRequestDto.terms(), user, terms);
+        userTermRepository.saveAll(userTerms);
+
+        // DTO 응답
+        return new UserResponseDto.SignupResponseDto(user.getId(), user.getEmail());
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/user/service/query/TermQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/query/TermQueryService.java
@@ -1,0 +1,21 @@
+package com.umc.barkit.domain.user.service.query;
+
+import com.umc.barkit.domain.user.converter.TermConverter;
+import com.umc.barkit.domain.user.dto.res.TermResponseDto;
+import com.umc.barkit.domain.user.repository.TermRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TermQueryService {
+
+    private final TermRepository termRepository;
+
+    // 약관 목록 조회
+    @Transactional(readOnly = true)
+    public TermResponseDto.TermListResponse getTerms(){
+        return TermConverter.toListResponse(termRepository.findActiveLatestTerms());
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
@@ -1,0 +1,24 @@
+package com.umc.barkit.domain.user.service.query;
+
+import com.umc.barkit.domain.user.dto.req.UserRequestDto;
+import com.umc.barkit.domain.user.dto.res.UserResponseDto;
+import com.umc.barkit.domain.user.dto.res.UserResponseDto.EmailCheckResponseDto;
+import com.umc.barkit.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Service
+@RequiredArgsConstructor
+public class UserQueryService {
+
+    private final UserRepository userRepository;
+
+    // 아이디 중복 확인
+    public UserResponseDto.EmailCheckResponseDto checkEmailAvailability(String email) {
+        boolean isAvailable = !userRepository.existsByEmail(email); // DB에서 해당 이메일이 존재하면 false 반환
+        String message = isAvailable ? "사용 가능한 아이디입니다" : "사용 불가능한 아이디입니다";
+        return new EmailCheckResponseDto(isAvailable, message);
+    }
+
+}

--- a/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.umc.barkit.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig{
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorizeRequests -> authorizeRequests
+                        .requestMatchers("/**").permitAll()  // 모든 요청에 대해 인증 없이 접근 허용
+                )
+                .formLogin(AbstractHttpConfigurer::disable)  // 폼 로그인 비활성화 (스프링 시큐리티 6.1 이상)
+                .csrf(AbstractHttpConfigurer::disable);  // REST API 환경에서 CSRF 비활성화 (스프링 시큐리티 6.1 이상)
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder(){
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
- 회원가입 기능과 관련된 API들 구현
  - 약관 조회: 사용자에게 약관을 조회할 수 있는 API 제공
  - 이메일 중복확인: 이메일 중복 여부를 체크하는 API 제공
  - 회원가입: 새로운 사용자 등록을 위한 API 제공

## 🛠️ 작업 상세 내용
- [x] 회원가입 API 구현
- [x] 이메일 중복확인 API 구현
- [x] 약관 조회 API 구현
- [x] 병합 충돌 해결 (build.gradle)

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)