### PR TITLE
♻️ [Refactor] UserMembershipBrand에 isMain 추가

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
+++ b/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
@@ -28,4 +28,6 @@ public class UserMembershipBrand extends BaseEntity {
     @Column(name = "barcode_raw_value", nullable = false, length = 50)
     private String barcodeRawValue;
 
+    @Column(name = "is_main", nullable = false)
+    private Boolean isMain = false;
 }

--- a/src/main/java/com/umc/barkit/domain/store/entity/mapping/StoreBrandMembershipBrand.java
+++ b/src/main/java/com/umc/barkit/domain/store/entity/mapping/StoreBrandMembershipBrand.java
@@ -25,8 +25,4 @@ public class StoreBrandMembershipBrand {
     @JoinColumn(name = "store_brand_id", nullable = false)
     private StoreBrand storeBrand;
 
-    @Column(name = "is_main")
-    private Boolean isMain;
-
-
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 사용자의 메인 멤버십 설정을 위한 컬럼 추가

## 🛠️ 작업 상세 내용
- [x] UserMembershipBrand에 isMain 추가
- [x] StoreBrandMembershipBrand에 isMain 삭제

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)