### PR TITLE
✨ [Feat] 로그인 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,12 @@ dependencies {
 	annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:7.0:jpa"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+
+	// Jwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+	implementation 'org.springframework.boot:spring-boot-configuration-processor'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -36,5 +36,13 @@ public class UserController implements UserControllerDocs{
         return ApiResponse.onSuccess(UserSuccessCode.CREATED, response);
     }
 
+    // 로그인 API
+    @PostMapping("/auth/login")
+    public ApiResponse<UserResponseDto.LoginResponseDto> login(
+            @RequestBody @Valid UserRequestDto.LoginRequestDto loginDto
+    ){
+        return ApiResponse.onSuccess(UserSuccessCode.LOGIN_OK, userQueryService.login(loginDto));
+    }
+
 
 }

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -5,6 +5,8 @@ import com.umc.barkit.domain.user.dto.res.UserResponseDto;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.RequestBody;
 
 public interface UserControllerDocs {
 
@@ -29,4 +31,16 @@ public interface UserControllerDocs {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "실패")
     })
     ApiResponse<UserResponseDto.SignupResponseDto> signup(UserRequestDto.SignupRequestDto signupRequestDto);
+
+
+    @Operation(
+            summary = "로그인 API",
+            description = "사용자가 입력한 이메일과 비밀번호로 로그인한 후, JWT access token을 반환합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공, JWT access token 반환"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "잘못된 로그인 정보(이메일/비밀번호 불일치)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자가 존재하지 않음")
+    })
+    ApiResponse<UserResponseDto.LoginResponseDto> login(@RequestBody @Valid UserRequestDto.LoginRequestDto loginDto);
 }

--- a/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
@@ -1,9 +1,11 @@
 package com.umc.barkit.domain.user.converter;
 
 import com.umc.barkit.domain.user.dto.req.UserRequestDto;
+import com.umc.barkit.domain.user.dto.res.UserResponseDto;
 import com.umc.barkit.domain.user.entity.Term;
 import com.umc.barkit.domain.user.entity.User;
 import com.umc.barkit.domain.user.entity.mapping.UserTerm;
+import com.umc.barkit.domain.user.enums.Role;
 import com.umc.barkit.domain.user.enums.UserStatus;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,12 +15,14 @@ public class UserConverter {
     // SignupRequestDto -> User Entity
     public static User toUser(
             UserRequestDto.SignupRequestDto dto,
-            String passwordHash
+            String passwordHash,
+            Role role
     ){
         return User.builder()
                 .name(dto.name())
                 .email(dto.email())
                 .passwordHash(passwordHash)
+                .role(role)
                 .phoneNumber(null)
                 .birthDate(null)
                 .status(UserStatus.ACTIVE) // 초기 상태는 ACTIVE
@@ -41,5 +45,15 @@ public class UserConverter {
                     return UserTerm.agree(user, term, agreedAt); // UserTerm 엔티티 생성
                 })
                 .toList();
+    }
+
+    public static UserResponseDto.LoginResponseDto toLoginDTO(
+            User user,
+            String accessToken
+    ){
+        return UserResponseDto.LoginResponseDto.builder()
+                .userId(user.getId())
+                .accessToken(accessToken)
+                .build();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -8,12 +8,15 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public class UserRequestDto {
+
+    // 이메일 중복확인
     public record EmailCheckRequestDto(
             @NotBlank
             String email
     ){
     }
 
+    // 회원가입
     public record SignupRequestDto(
             @NotBlank
             String name,
@@ -28,8 +31,17 @@ public class UserRequestDto {
             List<TermAgreement> terms
     ){}
 
+    // 약관 동의
     public record TermAgreement(
             @NotNull Long termId,
             @NotNull boolean isAgreed
+    ){}
+
+    // 로그인
+    public record LoginRequestDto(
+            @NotBlank
+            String email,
+            @NotBlank
+            String password
     ){}
 }

--- a/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
@@ -1,14 +1,25 @@
 package com.umc.barkit.domain.user.dto.res;
 
+import lombok.Builder;
+
 public class UserResponseDto {
 
+    // 이메일 중복확인
     public record EmailCheckResponseDto(
             boolean isAvailable,
             String message
     ){}
 
+    // 회원가입
     public record SignupResponseDto(
             Long userId,
             String email
+    ){}
+
+    // 로그인
+    @Builder
+    public record LoginResponseDto(
+            Long userId,
+            String accessToken
     ){}
 }

--- a/src/main/java/com/umc/barkit/domain/user/entity/User.java
+++ b/src/main/java/com/umc/barkit/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.umc.barkit.domain.user.entity;
 
+import com.umc.barkit.domain.user.enums.Role;
 import com.umc.barkit.domain.user.enums.UserStatus;
 import com.umc.barkit.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -28,6 +29,9 @@ public class User extends BaseEntity {
 
     @Column(name = "password_hash", length = 255)
     private String passwordHash;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
 
     @Column(name = "phone_number", length = 20)
     private String phoneNumber;

--- a/src/main/java/com/umc/barkit/domain/user/enums/Role.java
+++ b/src/main/java/com/umc/barkit/domain/user/enums/Role.java
@@ -1,0 +1,5 @@
+package com.umc.barkit.domain.user.enums;
+
+public enum Role {
+    ROLE_ADMIN, ROLE_USER
+}

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
@@ -9,8 +9,11 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum UserErrorCode implements BaseErrorCode {
 
+    INVALID(HttpStatus.UNAUTHORIZED, "AUTH4001", "이메일 또는 비밀번호가 올바르지 않습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH4004", "이미 사용 중인 아이디입니다."),
-    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH4003", "비밀번호 확인이 일치하지 않습니다.");
+    PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "AUTH4003", "비밀번호 확인이 일치하지 않습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "AUTH4005", "사용자를 찾을 수 없습니다.");
+
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum UserSuccessCode implements BaseSuccessCode {
 
     EMAIL_CHECK_OK(HttpStatus.OK, "AUTH2000", "아이디 중복 확인에 성공했습니다."),
-    CREATED(HttpStatus.CREATED, "AUTH2001", "회원가입이 성공적으로 완료되었습니다.");
+    CREATED(HttpStatus.CREATED, "AUTH2001", "회원가입이 성공적으로 완료되었습니다."),
+    LOGIN_OK(HttpStatus.OK, "AUTH2002", "로그인에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/barkit/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.umc.barkit.domain.user.repository;
 
 import com.umc.barkit.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);  // 아이디(이메일) 중복 확인
+    Optional<User> findByEmail(String email);
 }

--- a/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
@@ -6,6 +6,7 @@ import com.umc.barkit.domain.user.dto.res.UserResponseDto;
 import com.umc.barkit.domain.user.entity.Term;
 import com.umc.barkit.domain.user.entity.User;
 import com.umc.barkit.domain.user.entity.mapping.UserTerm;
+import com.umc.barkit.domain.user.enums.Role;
 import com.umc.barkit.domain.user.repository.TermRepository;
 import com.umc.barkit.domain.user.repository.UserRepository;
 import com.umc.barkit.domain.user.repository.UserTermRepository;
@@ -40,7 +41,7 @@ public class UserCommandService {
         String encodedPassword = passwordEncoder.encode(signupRequestDto.password());
 
         // User 생성
-        User user = UserConverter.toUser(signupRequestDto, encodedPassword);
+        User user = UserConverter.toUser(signupRequestDto, encodedPassword, Role.ROLE_USER);
 
         // User 저장
         userRepository.save(user);

--- a/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
@@ -1,18 +1,27 @@
 package com.umc.barkit.domain.user.service.query;
 
+import com.umc.barkit.domain.user.converter.UserConverter;
 import com.umc.barkit.domain.user.dto.req.UserRequestDto;
 import com.umc.barkit.domain.user.dto.res.UserResponseDto;
 import com.umc.barkit.domain.user.dto.res.UserResponseDto.EmailCheckResponseDto;
+import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.exception.UserException;
+import com.umc.barkit.domain.user.exception.code.UserErrorCode;
 import com.umc.barkit.domain.user.repository.UserRepository;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
+import com.umc.barkit.global.auth.jwt.JwtUtil;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Service
 @RequiredArgsConstructor
 public class UserQueryService {
 
     private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final PasswordEncoder encoder;
 
     // 아이디 중복 확인
     public UserResponseDto.EmailCheckResponseDto checkEmailAvailability(String email) {
@@ -21,4 +30,27 @@ public class UserQueryService {
         return new EmailCheckResponseDto(isAvailable, message);
     }
 
+    // 로그인
+    public UserResponseDto.LoginResponseDto login(
+            UserRequestDto.@Valid LoginRequestDto dto
+    ) {
+
+        // User 조회
+        User user = userRepository.findByEmail(dto.email())
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!encoder.matches(dto.password(), user.getPasswordHash())){
+            throw new UserException(UserErrorCode.INVALID);
+        }
+
+        // JWT 토큰 발급용 UserDetails
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        // 엑세스 토큰 발급
+        String accessToken = jwtUtil.createAccessToken(userDetails);
+
+        // DTO 조립
+        return UserConverter.toLoginDTO(user, accessToken);
+    }
 }

--- a/src/main/java/com/umc/barkit/global/auth/details/CustomUserDetails.java
+++ b/src/main/java/com/umc/barkit/global/auth/details/CustomUserDetails.java
@@ -1,0 +1,29 @@
+package com.umc.barkit.global.auth.details;
+
+import com.umc.barkit.domain.user.entity.User;
+import java.util.Collection;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> user.getRole().toString());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPasswordHash();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getEmail();
+    }
+
+}

--- a/src/main/java/com/umc/barkit/global/auth/details/CustomUserDetailsService.java
+++ b/src/main/java/com/umc/barkit/global/auth/details/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.umc.barkit.global.auth.details;
+
+import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.exception.UserException;
+import com.umc.barkit.domain.user.exception.code.UserErrorCode;
+import com.umc.barkit.domain.user.repository.UserRepository;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(
+            String username
+    ) throws UsernameNotFoundException {
+        // 검증할 Member 조회
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+        // CustomUserDetails 반환
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/umc/barkit/global/auth/handler/AuthenticationEntryPointImpl.java
+++ b/src/main/java/com/umc/barkit/global/auth/handler/AuthenticationEntryPointImpl.java
@@ -1,0 +1,31 @@
+package com.umc.barkit.global.auth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class AuthenticationEntryPointImpl implements AuthenticationEntryPoint{
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException
+    ) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        ApiResponse<Void> errorResponse = ApiResponse.onFailure(
+                GeneralErrorCode.UNAUTHORIZED,
+                null
+        );
+
+        objectMapper.writeValue(response.getOutputStream(), errorResponse);
+    }
+}

--- a/src/main/java/com/umc/barkit/global/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/umc/barkit/global/auth/jwt/JwtAuthFilter.java
@@ -1,0 +1,58 @@
+package com.umc.barkit.global.auth.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
+import com.umc.barkit.global.auth.details.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    protected void doFilterInternal(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull FilterChain filterChain
+    ) throws ServletException, IOException {
+
+        // 토큰 가져오기
+        String token = request.getHeader("Authorization");
+        // token이 없거나 Bearer가 아니면 넘기기
+        if (token == null || !token.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        // Bearer이면 추출
+        token = token.replace("Bearer ", "");
+        // AccessToken 검증하기: 올바른 토큰이면
+        if (jwtUtil.isValid(token)) {
+            // 토큰에서 이메일 추출
+            String email = jwtUtil.getEmail(token);
+            // 인증 객체 생성: 이메일로 찾아온 뒤, 인증 객체 생성
+            UserDetails user = customUserDetailsService.loadUserByUsername(email);
+            Authentication auth = new UsernamePasswordAuthenticationToken(
+                    user,
+                    null,
+                    user.getAuthorities()
+            );
+            // 인증 완료 후 SecurityContextHolder에 넣기
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        filterChain.doFilter(request, response);
+
+    }
+}

--- a/src/main/java/com/umc/barkit/global/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/umc/barkit/global/auth/jwt/JwtUtil.java
@@ -1,0 +1,92 @@
+package com.umc.barkit.global.auth.jwt;
+
+import com.umc.barkit.global.auth.details.CustomUserDetails;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.stream.Collectors;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+    private final SecretKey secretKey;
+    private final Duration accessExpiration;
+
+    public JwtUtil(
+            @Value("${jwt.token.secretKey}") String secret,
+            @Value("${jwt.token.expiration.access}") Long accessExpiration
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessExpiration = Duration.ofMillis(accessExpiration);
+    }
+
+    // AccessToken 생성
+    public String createAccessToken(CustomUserDetails user) {
+        return createToken(user, accessExpiration);
+    }
+
+    /** 토큰에서 이메일 가져오기
+     *
+     * @param token 유저 정보를 추출할 토큰
+     * @return 유저 이메일을 토큰에서 추출합니다
+     */
+    public String getEmail(String token) {
+        try {
+            return getClaims(token).getPayload().getSubject(); // Parsing해서 Subject 가져오기
+        } catch (JwtException e) {
+            return null;
+        }
+    }
+
+    /** 토큰 유효성 확인
+     *
+     * @param token 유효한지 확인할 토큰
+     * @return True, False 반환합니다
+     */
+    public boolean isValid(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException e) {
+            return false;
+        }
+    }
+
+    // 토큰 생성
+    private String createToken(CustomUserDetails user, Duration expiration) {
+        Instant now = Instant.now();
+
+        // 인가 정보
+        String authorities = user.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        return Jwts.builder()
+                .subject(user.getUsername()) // User 이메일을 Subject로
+                .claim("role", authorities)
+                .claim("email", user.getUsername())
+                .issuedAt(Date.from(now)) // 언제 발급한지
+                .expiration(Date.from(now.plus(expiration))) // 언제까지 유효한지
+                .signWith(secretKey) // sign할 Key
+                .compact();
+    }
+
+    // 토큰 정보 가져오기
+    private Jws<Claims> getClaims(String token) throws JwtException {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .clockSkewSeconds(60)
+                .build()
+                .parseSignedClaims(token);
+    }
+}
+

--- a/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
@@ -1,31 +1,67 @@
 package com.umc.barkit.global.config;
 
+import com.umc.barkit.global.auth.details.CustomUserDetailsService;
+import com.umc.barkit.global.auth.handler.AuthenticationEntryPointImpl;
+import com.umc.barkit.global.auth.jwt.JwtAuthFilter;
+import com.umc.barkit.global.auth.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig{
+
+    private final JwtUtil jwtUtil;
+    private final CustomUserDetailsService customUserDetailsService;
+
+    private final String[] allowUris = {
+            //"/**", // 모든 요청에 대해 인증 없이 접근 허용
+            "api/auth/login",
+            "api/auth/signup",
+            "/swagger-ui/**",
+            "/swagger-resources/**",
+            "/v3/api-docs/**",
+    };
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .authorizeHttpRequests(authorizeRequests -> authorizeRequests
-                        .requestMatchers("/**").permitAll()  // 모든 요청에 대해 인증 없이 접근 허용
+                        .requestMatchers(allowUris).permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .anyRequest().authenticated()
                 )
-                .formLogin(AbstractHttpConfigurer::disable)  // 폼 로그인 비활성화 (스프링 시큐리티 6.1 이상)
-                .csrf(AbstractHttpConfigurer::disable);  // REST API 환경에서 CSRF 비활성화 (스프링 시큐리티 6.1 이상)
+                .formLogin(AbstractHttpConfigurer::disable)  // 폼 로그인 비활성화
+                // JwtAuthFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
+                .addFilterBefore(jwtAuthFilter(), UsernamePasswordAuthenticationFilter.class)
+                .csrf(AbstractHttpConfigurer::disable) // REST API 환경에서 CSRF 비활성화
+                .exceptionHandling(exception -> exception.authenticationEntryPoint(authenticationEntryPoint()));
+
 
         return http.build();
     }
 
     @Bean
+    public JwtAuthFilter jwtAuthFilter() {
+        return new JwtAuthFilter(jwtUtil, customUserDetailsService);
+    }
+
+    @Bean
     public BCryptPasswordEncoder passwordEncoder(){
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new AuthenticationEntryPointImpl();
     }
 }

--- a/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
@@ -24,7 +24,7 @@ public class SecurityConfig{
     private final CustomUserDetailsService customUserDetailsService;
 
     private final String[] allowUris = {
-            //"/**", // 모든 요청에 대해 인증 없이 접근 허용
+            "/**", // 모든 요청에 대해 인증 없이 접근 허용
             "api/auth/login",
             "api/auth/signup",
             "/swagger-ui/**",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -39,3 +39,9 @@ google:
   api:
     base-url: https://places.googleapis.com
     key: ${GOOGLE_API_KEY}
+
+jwt:
+  token:
+    secretKey: ${JWT_SECRET_KEY}
+    expiration:
+      access: 14400000


### PR DESCRIPTION
## #️⃣ 기능 설명
* 로그인 성공 시 access token을 반환하고, 이를 이용하여 인증된 요청을 처리

## 🛠️ 작업 상세 내용
- [x] 로그인 API 엔드포인트 구현
- [x] 이메일 및 비밀번호 검증 로직 추가
- [x] access token 발급 로직 구현
- [x] 로그인 성공 시 access token 반환

## 📸 스크린샷 (선택)
1. 로컬 테스트(로그인/회원가입만 열어뒀을 때)
<img width="522" height="227" alt="image" src="https://github.com/user-attachments/assets/de676c40-4181-42a2-9666-b9fa2c02f514" />

<p></p>

2. 로그인 성공
<img width="902" height="516" alt="image" src="https://github.com/user-attachments/assets/a544e828-ad9d-4565-88a0-ca2a3d860222" />
<img width="852" height="332" alt="image" src="https://github.com/user-attachments/assets/50dc8e9d-5eef-42d0-89c1-f9ea8680c1cb" />

<p></p>

3. 로그인 실패(아이디 오류)
<img width="902" height="522" alt="image" src="https://github.com/user-attachments/assets/e589a87d-68f1-467b-a412-fd1b25d41dac" />
<img width="862" height="248" alt="image" src="https://github.com/user-attachments/assets/b7df3206-92fd-4b82-9e51-ed78ef9b0f17" />

<p></p>

4. 로그인 실패(비밀번호 오류)
<img width="905" height="513" alt="image" src="https://github.com/user-attachments/assets/987491eb-0fd0-4235-8e8c-35d99c22b07d" />
<img width="855" height="248" alt="image" src="https://github.com/user-attachments/assets/47adcbe9-9568-4534-a0aa-908bd1988aeb" />

<p></p>

5. 로그인 성공 후 JWT 토큰으로 상위 4개 인기 브랜드 조회 API 테스트(인증된 요청 처리)
<img width="841" height="601" alt="image" src="https://github.com/user-attachments/assets/4ea9fac1-b94a-4dd5-902d-8f9a4ecf437f" />

<p></p>

6. JWT 토큰 없이 상위 4개 인기 브랜드 조회 API 테스트
<img width="498" height="205" alt="image" src="https://github.com/user-attachments/assets/9473603d-5a72-4af2-818a-abb3eef71079" />

<p></p>

7. 잘못된 JWT 토큰으로 상위 4개 인기 브랜드 조회 API 테스트
<img width="800" height="326" alt="image" src="https://github.com/user-attachments/assets/cb59c3bf-08f9-490d-b9e3-2948f1667349" />
<img width="481" height="251" alt="image" src="https://github.com/user-attachments/assets/9a3d8ee1-591b-407e-b218-5ad87e9b098b" />


## 💬 기타(공유사항 to 리뷰어)
* **현재는 피드백 & 개발 기간이라 모든 요청을 허용해두었습니다.**‼️
* 로컬 환경에서는 인증된 요청에 대한 처리 테스트를 완료했습니다.
* users 테이블에 이미 회원가입된 유저 데이터들은 role 컬럼에 ROLE_USER를 추가해두었습니다.
<img width="157" height="322" alt="image" src="https://github.com/user-attachments/assets/b3c795dd-2eac-4975-80ff-cabe8040c5da" />

