### PR TITLE
✨ [Feat] 멤버십 브랜드 검색 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/MembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/MembershipBrandController.java
@@ -5,10 +5,12 @@ import com.umc.barkit.domain.membership.service.MembershipBrandQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -42,6 +44,31 @@ public class MembershipBrandController {
     public ResponseEntity<ApiResponse<MembershipBrandResponseDTO.PopularBrandsDTO>> getPopularMembershipBrands() {
         MembershipBrandResponseDTO.PopularBrandsDTO result =
                 membershipBrandQueryService.getPopularMembershipBrands();
+
+        return ResponseEntity
+                .status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "멤버십 브랜드 검색",
+            description = "키워드로 멤버십 브랜드를 검색합니다. " +
+                    "대소문자 구분 없이 부분 일치로 검색되며, " +
+                    "커서 기반 페이지네이션을 지원합니다."
+    )
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<MembershipBrandResponseDTO.SearchResultDTO>> searchMembershipBrands(
+            @Parameter(description = "검색 키워드 (대소문자 무시, 부분 일치)", required = true)
+            @RequestParam String keyword,
+
+            @Parameter(description = "커서 (이전 응답의 nextCursor 값)", required = false, example = "0")
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(description = "한 번에 가져올 개수 (기본값: 20)", required = false, example = "20")
+            @RequestParam(required = false) Integer limit
+    ) {
+        MembershipBrandResponseDTO.SearchResultDTO result =
+                membershipBrandQueryService.searchMembershipBrands(keyword, cursor, limit);
 
         return ResponseEntity
                 .status(GeneralSuccessCode.OK.getStatus())

--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -1,4 +1,47 @@
 package com.umc.barkit.domain.membership.controller;
 
+import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.service.UserMembershipBrandQueryService;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user-membership-brands")
 public class UserMembershipBrandController {
+
+    private final UserMembershipBrandQueryService userMembershipBrandQueryService;
+
+    @Operation(
+            summary = "사용자 보유 멤버십 브랜드 검색",
+            description = "로그인한 사용자가 보유한 멤버십 브랜드를 키워드로 검색합니다. " +
+                    "대소문자 무시, 띄어쓰기/특수문자 무시, 커서 기반 페이지네이션을 지원합니다."
+    )
+    @GetMapping("/search")
+    public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.SearchResultDTO>> searchUserMembershipBrands(
+            @Parameter(description = "사용자 ID", required = true, example = "100")
+            @RequestParam Long userId,  // TODO: 추후 JWT에서 추출
+
+            @Parameter(description = "검색 키워드", required = true)
+            @RequestParam String keyword,
+
+            @Parameter(description = "커서", required = false, example = "0")
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(description = "한 번에 가져올 개수 (기본값: 20)", required = false, example = "20")
+            @RequestParam(required = false) Integer limit
+    ) {
+        UserMembershipBrandResponseDTO.SearchResultDTO result =
+                userMembershipBrandQueryService.searchUserMembershipBrands(userId, keyword, cursor, limit);
+
+        return ResponseEntity
+                .status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -1,0 +1,4 @@
+package com.umc.barkit.domain.membership.controller;
+
+public class UserMembershipBrandController {
+}

--- a/src/main/java/com/umc/barkit/domain/membership/converter/MembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/MembershipBrandConverter.java
@@ -56,4 +56,18 @@ public class MembershipBrandConverter {
                 .brands(brandDTOs)
                 .build();
     }
+
+    public static MembershipBrandResponseDTO.SearchResultDTO toSearchResultDTO(
+            List<MembershipBrand> brands,
+            Long nextCursor,
+            Boolean hasNext
+    ) {
+        List<MembershipBrandResponseDTO.BrandSimpleDTO> brandDTOs = toBrandSimpleDTOList(brands);
+
+        return MembershipBrandResponseDTO.SearchResultDTO.builder()
+                .brands(brandDTOs)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -1,4 +1,49 @@
 package com.umc.barkit.domain.membership.converter;
 
+import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.entity.MembershipBrand;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
+import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
 public class UserMembershipBrandConverter {
+
+    private final MembershipBrandRepository membershipBrandRepository;
+
+    public UserMembershipBrandResponseDTO.SearchResultDTO toSearchResultDTO(
+            List<UserMembershipBrand> userBrands,
+            Long nextCursor,
+            Boolean hasNext
+    ) {
+        List<UserMembershipBrandResponseDTO.UserBrandDTO> brandDTOs = userBrands.stream()
+                .map(this::toUserBrandDTO)
+                .collect(Collectors.toList());
+
+        return UserMembershipBrandResponseDTO.SearchResultDTO.builder()
+                .brands(brandDTOs)
+                .nextCursor(nextCursor)
+                .hasNext(hasNext)
+                .build();
+    }
+
+    public UserMembershipBrandResponseDTO.UserBrandDTO toUserBrandDTO(UserMembershipBrand userBrand) {
+        // MembershipBrand 조회
+        MembershipBrand brand = membershipBrandRepository
+                .findById(userBrand.getMembershipBrandId())
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.BRAND4001));
+
+        return UserMembershipBrandResponseDTO.UserBrandDTO.builder()
+                .userMembershipBrandId(userBrand.getId())
+                .name(brand.getName())
+                .logoUrl(brand.getLogoUrl())
+                .build();
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -1,0 +1,4 @@
+package com.umc.barkit.domain.membership.converter;
+
+public class UserMembershipBrandConverter {
+}

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/MembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/MembershipBrandResponseDTO.java
@@ -47,4 +47,14 @@ public class MembershipBrandResponseDTO {
         private Long membershipBrandId;
         private String name;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchResultDTO {
+        private List<BrandSimpleDTO> brands;
+        private Long nextCursor;
+        private Boolean hasNext;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -1,0 +1,4 @@
+package com.umc.barkit.domain.membership.dto.response;
+
+public class UserMembershipBrandResponseDTO {
+}

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -1,4 +1,31 @@
 package com.umc.barkit.domain.membership.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
 public class UserMembershipBrandResponseDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SearchResultDTO {
+        private List<UserBrandDTO> brands;
+        private Long nextCursor;
+        private Boolean hasNext;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserBrandDTO {
+        private Long userMembershipBrandId;
+        private String name;
+        private String logoUrl;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepositoryCustom.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepositoryCustom.java
@@ -11,4 +11,7 @@ public interface MembershipBrandRepositoryCustom {
 
     // 인기 멤버십 브랜드 10개 조회 (QueryDSL)
     List<MembershipBrand> findTop10ByRegistrationCount();
+
+    // 키워드로 멤버십 브랜드 검색 (커서 페이지네이션)
+    List<MembershipBrand> searchByKeyword(String keyword, Long cursor, Integer limit);
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.umc.barkit.domain.membership.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.barkit.domain.membership.entity.MembershipBrand;
 import com.umc.barkit.domain.membership.entity.QMembershipBrand;
@@ -7,7 +9,9 @@ import com.umc.barkit.domain.membership.entity.QUserMembershipBrand;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Repository
 @RequiredArgsConstructor
@@ -17,6 +21,14 @@ public class MembershipBrandRepositoryImpl implements MembershipBrandRepositoryC
 
     private final QMembershipBrand membershipBrand = QMembershipBrand.membershipBrand;
     private final QUserMembershipBrand userMembershipBrand = QUserMembershipBrand.userMembershipBrand;
+
+    // 영문 → 한글 매핑
+    private static final Map<String, String> ENGLISH_TO_KOREAN = new HashMap<>() {{
+        put("naver", "네이버");
+        put("kakao", "카카오");
+        put("happy", "해피");
+        put("point", "포인트");
+    }};
 
     @Override
     public List<MembershipBrand> findTop4ByRegistrationCount() {
@@ -45,6 +57,41 @@ public class MembershipBrandRepositoryImpl implements MembershipBrandRepositoryC
                         membershipBrand.id.asc()
                 )
                 .limit(10)
+                .fetch();
+    }
+
+    @Override
+    public List<MembershipBrand> searchByKeyword(String keyword, Long cursor, Integer limit) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            // 1. 검색어 정규화
+            String normalizedKeyword = keyword.replaceAll("[\\s.+-]", "").toLowerCase();
+
+            // 2. 영문 → 한글 변환 (네이버, 카카오만)
+            String mappedKeyword = ENGLISH_TO_KOREAN.getOrDefault(normalizedKeyword, normalizedKeyword);
+
+            // 3. 검색 (원본 OR 매핑된 키워드)
+            builder.and(
+                    Expressions.stringTemplate(
+                                    "REPLACE(REPLACE(REPLACE(REPLACE(LOWER({0}), ' ', ''), '.', ''), '+', ''), '-', '')",
+                                    membershipBrand.name
+                            ).contains(normalizedKeyword)
+                            .or(
+                                    membershipBrand.name.containsIgnoreCase(mappedKeyword)
+                            )
+            );
+        }
+
+        if (cursor != null) {
+            builder.and(membershipBrand.id.gt(cursor));
+        }
+
+        return queryFactory
+                .selectFrom(membershipBrand)
+                .where(builder)
+                .orderBy(membershipBrand.id.asc())
+                .limit(limit + 1)
                 .fetch();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserMembershipBrandRepository extends JpaRepository<UserMembershipBrand, Long> {
+public interface UserMembershipBrandRepository extends JpaRepository<UserMembershipBrand, Long>, UserMembershipBrandRepositoryCustom {
 
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.umc.barkit.domain.membership.repository;
+
+public interface UserMembershipBrandRepositoryCustom {
+}

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
@@ -1,4 +1,16 @@
 package com.umc.barkit.domain.membership.repository;
 
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+
+import java.util.List;
+
 public interface UserMembershipBrandRepositoryCustom {
+
+    // 사용자 보유 멤버십 브랜드 검색 (커서 페이지네이션)
+    List<UserMembershipBrand> searchByUserIdAndKeyword(
+            Long userId,
+            String keyword,
+            Long cursor,
+            Integer limit
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
@@ -1,4 +1,74 @@
 package com.umc.barkit.domain.membership.repository;
 
-public class UserMembershipBrandRepositoryImpl {
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.umc.barkit.domain.membership.entity.QMembershipBrand.membershipBrand;
+import static com.umc.barkit.domain.membership.entity.QUserMembershipBrand.userMembershipBrand;
+
+@RequiredArgsConstructor
+public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserMembershipBrand> searchByUserIdAndKeyword(
+            Long userId,
+            String keyword,
+            Long cursor,
+            Integer limit
+    ) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        // 1. 사용자 ID 필터 (필수)
+        builder.and(userMembershipBrand.userId.eq(userId));
+
+        // 2. 키워드 검색 (MembershipBrand name 기준)
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            String normalizedKeyword = keyword.replaceAll("[\\s.+-]", "").toLowerCase();
+
+            // 영문 → 한글 매핑
+            String mappedKeyword = getMappedKeyword(normalizedKeyword);
+
+            builder.and(
+                    Expressions.stringTemplate(
+                                    "REPLACE(REPLACE(REPLACE(REPLACE(LOWER({0}), ' ', ''), '.', ''), '+', ''), '-', '')",
+                                    membershipBrand.name
+                            ).contains(normalizedKeyword)
+                            .or(
+                                    membershipBrand.name.containsIgnoreCase(mappedKeyword)
+                            )
+            );
+        }
+
+        // 3. 커서 조건
+        if (cursor != null) {
+            builder.and(userMembershipBrand.id.gt(cursor));
+        }
+
+        // 4. 쿼리 실행 (JOIN 필수!)
+        return queryFactory
+                .selectFrom(userMembershipBrand)
+                .join(membershipBrand)
+                .on(userMembershipBrand.membershipBrandId.eq(membershipBrand.id))
+                .where(builder)
+                .orderBy(userMembershipBrand.id.asc())
+                .limit(limit + 1)
+                .fetch();
+    }
+
+    private String getMappedKeyword(String keyword) {
+        if (keyword.startsWith("naver") || keyword.startsWith("nav") || keyword.startsWith("na")) {
+            return "네이버";
+        }
+        if (keyword.startsWith("kakao") || keyword.startsWith("kak") || keyword.startsWith("ka")) {
+            return "카카오";
+        }
+        return keyword;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.umc.barkit.domain.membership.repository;
+
+public class UserMembershipBrandRepositoryImpl {
+}

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
@@ -6,7 +6,9 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import lombok.RequiredArgsConstructor;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.umc.barkit.domain.membership.entity.QMembershipBrand.membershipBrand;
 import static com.umc.barkit.domain.membership.entity.QUserMembershipBrand.userMembershipBrand;
@@ -15,6 +17,13 @@ import static com.umc.barkit.domain.membership.entity.QUserMembershipBrand.userM
 public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+
+    private static final Map<String, String> ENGLISH_TO_KOREAN = new HashMap<>() {{
+        put("naver", "네이버");
+        put("kakao", "카카오");
+        put("happy", "해피");
+        put("point", "포인트");
+    }};
 
     @Override
     public List<UserMembershipBrand> searchByUserIdAndKeyword(
@@ -32,8 +41,7 @@ public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRep
         if (keyword != null && !keyword.trim().isEmpty()) {
             String normalizedKeyword = keyword.replaceAll("[\\s.+-]", "").toLowerCase();
 
-            // 영문 → 한글 매핑
-            String mappedKeyword = getMappedKeyword(normalizedKeyword);
+            String mappedKeyword = ENGLISH_TO_KOREAN.getOrDefault(normalizedKeyword, normalizedKeyword);
 
             builder.and(
                     Expressions.stringTemplate(
@@ -60,15 +68,5 @@ public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRep
                 .orderBy(userMembershipBrand.id.asc())
                 .limit(limit + 1)
                 .fetch();
-    }
-
-    private String getMappedKeyword(String keyword) {
-        if (keyword.startsWith("naver") || keyword.startsWith("nav") || keyword.startsWith("na")) {
-            return "네이버";
-        }
-        if (keyword.startsWith("kakao") || keyword.startsWith("kak") || keyword.startsWith("ka")) {
-            return "카카오";
-        }
-        return keyword;
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/MembershipBrandQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/MembershipBrandQueryService.java
@@ -9,4 +9,11 @@ public interface MembershipBrandQueryService {
 
     // 인기 멤버십 브랜드 10개 조회
     MembershipBrandResponseDTO.PopularBrandsDTO getPopularMembershipBrands();
+
+    // 멤버십 브랜드 검색 (커서 페이지네이션)
+    MembershipBrandResponseDTO.SearchResultDTO searchMembershipBrands(
+            String keyword,
+            Long cursor,
+            Integer limit
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/MembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/MembershipBrandQueryServiceImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,23 +19,43 @@ public class MembershipBrandQueryServiceImpl implements MembershipBrandQueryServ
 
     @Override
     public MembershipBrandResponseDTO.Top4BrandsDTO getTop4MembershipBrands() {
-        List<MembershipBrand> top4Brands = membershipBrandRepository
-                .findTop4ByRegistrationCount()
-                .stream()
-                .limit(4)
-                .collect(Collectors.toList());
-
+        List<MembershipBrand> top4Brands = membershipBrandRepository.findTop4ByRegistrationCount();
         return MembershipBrandConverter.toTop4BrandsDTO(top4Brands);
     }
 
     @Override
     public MembershipBrandResponseDTO.PopularBrandsDTO getPopularMembershipBrands() {
-        List<MembershipBrand> popularBrands = membershipBrandRepository
-                .findTop10ByRegistrationCount()
-                .stream()
-                .limit(10)
-                .collect(Collectors.toList());
-
+        List<MembershipBrand> popularBrands = membershipBrandRepository.findTop10ByRegistrationCount();
         return MembershipBrandConverter.toPopularBrandsDTO(popularBrands);
+    }
+
+    @Override
+    public MembershipBrandResponseDTO.SearchResultDTO searchMembershipBrands(
+            String keyword,
+            Long cursor,
+            Integer limit
+    ) {
+        // 1. limit 기본값 설정
+        int pageSize = (limit != null && limit > 0) ? limit : 20;
+
+        // 2. DB 조회 (limit + 1개 조회하여 hasNext 확인)
+        List<MembershipBrand> brands = membershipBrandRepository
+                .searchByKeyword(keyword, cursor, pageSize);
+
+        // 3. hasNext 확인
+        boolean hasNext = brands.size() > pageSize;
+
+        // 4. 실제 반환할 데이터
+        List<MembershipBrand> resultBrands = hasNext
+                ? brands.subList(0, pageSize)
+                : brands;
+
+        // 5. nextCursor 계산
+        Long nextCursor = hasNext
+                ? resultBrands.get(resultBrands.size() - 1).getId()
+                : null;
+
+        // 6. DTO 변환 및 반환
+        return MembershipBrandConverter.toSearchResultDTO(resultBrands, nextCursor, hasNext);
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
@@ -1,0 +1,4 @@
+package com.umc.barkit.domain.membership.service;
+
+public interface UserMembershipBrandQueryService {
+}

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
@@ -1,4 +1,14 @@
 package com.umc.barkit.domain.membership.service;
 
+import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+
 public interface UserMembershipBrandQueryService {
+
+    // 사용자 보유 멤버십 브랜드 검색
+    UserMembershipBrandResponseDTO.SearchResultDTO searchUserMembershipBrands(
+            Long userId,
+            String keyword,
+            Long cursor,
+            Integer limit
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -1,0 +1,4 @@
+package com.umc.barkit.domain.membership.service;
+
+public class UserMembershipBrandQueryServiceImpl {
+}

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -1,4 +1,51 @@
 package com.umc.barkit.domain.membership.service;
 
-public class UserMembershipBrandQueryServiceImpl {
+import com.umc.barkit.domain.membership.converter.UserMembershipBrandConverter;
+import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQueryService {
+
+    private final UserMembershipBrandRepository userMembershipBrandRepository;
+    private final UserMembershipBrandConverter userMembershipBrandConverter;
+
+    @Override
+    public UserMembershipBrandResponseDTO.SearchResultDTO searchUserMembershipBrands(
+            Long userId,
+            String keyword,
+            Long cursor,
+            Integer limit
+    ) {
+        // 1. limit 기본값 설정
+        int pageSize = (limit != null && limit > 0) ? limit : 20;
+
+        // 2. DB 조회
+        List<UserMembershipBrand> brands = userMembershipBrandRepository
+                .searchByUserIdAndKeyword(userId, keyword, cursor, pageSize);
+
+        // 3. hasNext 확인
+        boolean hasNext = brands.size() > pageSize;
+
+        // 4. 실제 반환할 데이터
+        List<UserMembershipBrand> resultBrands = hasNext
+                ? brands.subList(0, pageSize)
+                : brands;
+
+        // 5. nextCursor 계산
+        Long nextCursor = hasNext
+                ? resultBrands.get(resultBrands.size() - 1).getId()
+                : null;
+
+        // 6. DTO 변환 및 반환
+        return userMembershipBrandConverter.toSearchResultDTO(resultBrands, nextCursor, hasNext);
+    }
 }

--- a/src/main/java/com/umc/barkit/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/umc/barkit/global/apiPayload/code/GeneralErrorCode.java
@@ -21,7 +21,19 @@ public enum GeneralErrorCode implements BaseErrorCode {
 
     // ===== Google API =====
     GOOGLE_NO_RESULT(HttpStatus.NOT_FOUND, "GOOGLE4001", "구글 플레이스 상세 정보를 찾을 수 없습니다."),
-    GOOGLE_API_ERROR(HttpStatus.BAD_GATEWAY, "GOOGLE5001", "구글 API 호출 중 오류가 발생했습니다.");
+    GOOGLE_API_ERROR(HttpStatus.BAD_GATEWAY, "GOOGLE5001", "구글 API 호출 중 오류가 발생했습니다."),
+
+    // ========== 멤버십 브랜드 에러 (BRAND) ==========
+    BRAND4001(HttpStatus.NOT_FOUND, "BRAND4001", "존재하지 않는 브랜드입니다."),
+    BRAND4002(HttpStatus.CONFLICT, "BRAND4002", "이미 존재하는 브랜드입니다."),
+
+    // ========== 멤버십 카드 에러 (MEMBERSHIP) ==========
+    MEMBERSHIP4001(HttpStatus.BAD_REQUEST, "MEMBERSHIP4001", "멤버십 번호를 입력해주세요."),
+    MEMBERSHIP4002(HttpStatus.BAD_REQUEST, "MEMBERSHIP4002", "멤버십 번호는 최대 20자까지 입력 가능합니다."),
+    MEMBERSHIP4003(HttpStatus.BAD_REQUEST, "MEMBERSHIP4003", "멤버십 번호는 숫자만 입력 가능합니다."),
+
+    // ========== 바코드 에러 (BARCODE) ==========
+    BARCODE4001(HttpStatus.BAD_REQUEST, "BARCODE4001", "지원하지 않는 바코드 형식입니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## #️⃣ 기능 설명
> 멤버십 브랜드 검색 및 사용자 보유 멤버십 브랜드 검색 API 구현
> 키워드 기반 검색으로 대소문자, 띄어쓰기, 특수문자를 무시하며 영문/한글 매핑과 커서 기반 페이지네이션을 지원

## 🛠️ 작업 상세 내용
- [x] 멤버십 브랜드 검색 API 구현 (GET /api/membership-brands/search)
- [x] 사용자 보유 멤버십 브랜드 검색 API 구현 (GET /api/user-membership-brands/search)
- [x] 대소문자 무시 검색 (KT = kt = Kt)
- [x] 띄어쓰기 및 특수문자 무시 검색 (LGU+ = lgu+ = lgu, L.POINT = lpoint)
- [x] 영문 → 한글 부분 매핑 검색 (naver → 네이버, kakao → 카카오)
- [x] 커서 기반 페이지네이션 (기본 20개)
- [x] 사용자 보유 브랜드 검색 시 JOIN을 통한 효율적 조회

## 📸 스크린샷 (선택)
- 멤버십 브랜드 검색
<img width="702" height="796" alt="스크린샷 2026-01-31 오전 3 54 14" src="https://github.com/user-attachments/assets/78785086-3047-4c25-912b-ce1dfd882d72" />


- 사용자 보유 멤버십 브랜드 검색
<img width="606" height="828" alt="스크린샷 2026-01-31 오후 3 54 17" src="https://github.com/user-attachments/assets/e7d52014-a3b5-4221-bfe2-37e0e5855457" />


## 💬 기타(공유사항 to 리뷰어)
- userId는 현재 RequestParam으로 받고 있으며, 추후 JWT 인증 구현 시 토큰에서 추출하도록 수정할 예정입니다