### PR TITLE
✨ [Feat] 멤버십 번호로 등록 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -1,6 +1,8 @@
 package com.umc.barkit.domain.membership.controller;
 
+import com.umc.barkit.domain.membership.dto.request.UserMembershipBrandRequestDTO;
 import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.service.UserMembershipBrandCommandService;
 import com.umc.barkit.domain.membership.service.UserMembershipBrandQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
@@ -17,6 +19,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserMembershipBrandController {
 
     private final UserMembershipBrandQueryService userMembershipBrandQueryService;
+    private final UserMembershipBrandCommandService userMembershipBrandCommandService;  // 변경
 
     @Operation(
             summary = "사용자 보유 멤버십 브랜드 검색",
@@ -39,6 +42,30 @@ public class UserMembershipBrandController {
     ) {
         UserMembershipBrandResponseDTO.SearchResultDTO result =
                 userMembershipBrandQueryService.searchUserMembershipBrands(userId, keyword, cursor, limit);
+
+        return ResponseEntity
+                .status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "멤버십 번호 등록",
+            description = "사용자가 멤버십 번호를 직접 입력하여 등록합니다. " +
+                    "프론트에서 멤버십 번호로 바코드 문자열을 추출하여 같이 전달합니다. " +
+                    "추후 userId가 아닌 JWT에서 추출하도록 변경 예정"
+    )
+    @PostMapping("/{membershipBrandId}/number")
+    public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.RegisterMembershipResultDTO>> registerMembership(
+            @Parameter(description = "사용자 ID", required = true, example = "100")
+            @RequestParam Long userId,  // TODO: 추후 JWT에서 추출
+
+            @Parameter(description = "멤버십 브랜드 ID", required = true, example = "1")
+            @PathVariable Long membershipBrandId,
+
+            @RequestBody UserMembershipBrandRequestDTO.RegisterMembershipDTO request
+    ) {
+        UserMembershipBrandResponseDTO.RegisterMembershipResultDTO result =
+                userMembershipBrandCommandService.registerMembership(userId, membershipBrandId, request);
 
         return ResponseEntity
                 .status(GeneralSuccessCode.OK.getStatus())

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -1,6 +1,7 @@
 package com.umc.barkit.domain.membership.converter;
 
 import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.dto.request.UserMembershipBrandRequestDTO;
 import com.umc.barkit.domain.membership.entity.MembershipBrand;
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
@@ -44,6 +45,32 @@ public class UserMembershipBrandConverter {
                 .userMembershipBrandId(userBrand.getId())
                 .name(brand.getName())
                 .logoUrl(brand.getLogoUrl())
+                .build();
+    }
+
+    // Request → Entity
+    public static UserMembershipBrand toUserMembershipBrand(
+            Long userId,
+            Long membershipBrandId,
+            UserMembershipBrandRequestDTO.RegisterMembershipDTO request
+    ) {
+        return UserMembershipBrand.builder()
+                .userId(userId)
+                .membershipBrandId(membershipBrandId)
+                .membershipNumber(request.getMembershipNumber())
+                .barcodeRawValue(request.getBarcodeRawValue())
+                .isMain(false)
+                .build();
+    }
+
+    // Entity → Response DTO
+    public static UserMembershipBrandResponseDTO.RegisterMembershipResultDTO toRegisterMembershipResultDTO(
+            UserMembershipBrand userMembershipBrand
+    ) {
+        return UserMembershipBrandResponseDTO.RegisterMembershipResultDTO.builder()
+                .userMembershipBrandId(userMembershipBrand.getId())
+                .membershipNumber(userMembershipBrand.getMembershipNumber())
+                .barcodeRawValue(userMembershipBrand.getBarcodeRawValue())
                 .build();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/dto/request/UserMembershipBrandRequestDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/request/UserMembershipBrandRequestDTO.java
@@ -1,0 +1,18 @@
+package com.umc.barkit.domain.membership.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserMembershipBrandRequestDTO {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegisterMembershipDTO {
+        private String membershipNumber;   // 멤버십 번호
+        private String barcodeRawValue;    // 바코드 문자열 (프론트에서 추출)
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -28,4 +28,14 @@ public class UserMembershipBrandResponseDTO {
         private String name;
         private String logoUrl;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class RegisterMembershipResultDTO {
+        private Long userMembershipBrandId;
+        private String membershipNumber;
+        private String barcodeRawValue;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
@@ -13,4 +13,7 @@ public interface UserMembershipBrandRepositoryCustom {
             Long cursor,
             Integer limit
     );
+
+    // 멤버십 브랜드 중복 체크
+    boolean existsByUserIdAndMembershipBrandId(Long userId, Long membershipBrandId);
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
@@ -69,4 +69,18 @@ public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRep
                 .limit(limit + 1)
                 .fetch();
     }
+
+    @Override
+    public boolean existsByUserIdAndMembershipBrandId(Long userId, Long membershipBrandId) {
+        Long count = queryFactory
+                .select(userMembershipBrand.count())
+                .from(userMembershipBrand)
+                .where(
+                        userMembershipBrand.userId.eq(userId),
+                        userMembershipBrand.membershipBrandId.eq(membershipBrandId)
+                )
+                .fetchOne();
+
+        return count != null && count > 0;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandCommandService.java
@@ -1,0 +1,14 @@
+package com.umc.barkit.domain.membership.service;
+
+import com.umc.barkit.domain.membership.dto.request.UserMembershipBrandRequestDTO;
+import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+
+public interface UserMembershipBrandCommandService {
+
+    // 멤버십 번호로 등록
+    UserMembershipBrandResponseDTO.RegisterMembershipResultDTO registerMembership(
+            Long userId,
+            Long membershipBrandId,
+            UserMembershipBrandRequestDTO.RegisterMembershipDTO request
+    );
+}

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandCommandServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandCommandServiceImpl.java
@@ -1,0 +1,75 @@
+package com.umc.barkit.domain.membership.service;
+
+import com.umc.barkit.domain.membership.converter.UserMembershipBrandConverter;
+import com.umc.barkit.domain.membership.dto.request.UserMembershipBrandRequestDTO;
+import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
+import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserMembershipBrandCommandServiceImpl implements UserMembershipBrandCommandService {
+
+    private final UserMembershipBrandRepository userMembershipBrandRepository;
+    private final MembershipBrandRepository membershipBrandRepository;
+
+    @Override
+    @Transactional
+    public UserMembershipBrandResponseDTO.RegisterMembershipResultDTO registerMembership(
+            Long userId,
+            Long membershipBrandId,
+            UserMembershipBrandRequestDTO.RegisterMembershipDTO request
+    ) {
+        // 1. 유효성 검사
+        validateMembershipNumber(request.getMembershipNumber());
+
+        // 2. 브랜드 존재 여부 확인
+        membershipBrandRepository.findById(membershipBrandId)
+                .orElseThrow(() -> new GeneralException(GeneralErrorCode.BRAND4001));
+
+        // 3. 중복 체크
+        if (userMembershipBrandRepository.existsByUserIdAndMembershipBrandId(userId, membershipBrandId)) {
+            throw new GeneralException(GeneralErrorCode.MEMBERSHIP4005);
+        }
+
+        // 4. Entity 생성
+        UserMembershipBrand userMembershipBrand = UserMembershipBrandConverter.toUserMembershipBrand(
+                userId, membershipBrandId, request
+        );
+
+        // 5. DB 저장
+        UserMembershipBrand saved = userMembershipBrandRepository.save(userMembershipBrand);
+
+        // 6. 응답 DTO 변환 및 반환
+        return UserMembershipBrandConverter.toRegisterMembershipResultDTO(saved);
+    }
+
+    // ===== 유효성 검사 =====
+    private void validateMembershipNumber(String membershipNumber) {
+        // 빈 값 체크
+        if (membershipNumber == null || membershipNumber.trim().isEmpty()) {
+            throw new GeneralException(GeneralErrorCode.MEMBERSHIP4001);
+        }
+
+        // 숫자만 체크
+        if (!membershipNumber.matches("\\d+")) {
+            throw new GeneralException(GeneralErrorCode.MEMBERSHIP4003);
+        }
+
+        // 최소 길이 체크 (12자)
+        if (membershipNumber.length() < 12) {
+            throw new GeneralException(GeneralErrorCode.MEMBERSHIP4004);
+        }
+
+        // 최대 길이 체크 (20자)
+        if (membershipNumber.length() > 20) {
+            throw new GeneralException(GeneralErrorCode.MEMBERSHIP4002);
+        }
+    }
+}

--- a/src/main/java/com/umc/barkit/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/umc/barkit/global/apiPayload/code/GeneralErrorCode.java
@@ -25,12 +25,13 @@ public enum GeneralErrorCode implements BaseErrorCode {
 
     // ========== 멤버십 브랜드 에러 (BRAND) ==========
     BRAND4001(HttpStatus.NOT_FOUND, "BRAND4001", "존재하지 않는 브랜드입니다."),
-    BRAND4002(HttpStatus.CONFLICT, "BRAND4002", "이미 존재하는 브랜드입니다."),
 
     // ========== 멤버십 카드 에러 (MEMBERSHIP) ==========
     MEMBERSHIP4001(HttpStatus.BAD_REQUEST, "MEMBERSHIP4001", "멤버십 번호를 입력해주세요."),
     MEMBERSHIP4002(HttpStatus.BAD_REQUEST, "MEMBERSHIP4002", "멤버십 번호는 최대 20자까지 입력 가능합니다."),
     MEMBERSHIP4003(HttpStatus.BAD_REQUEST, "MEMBERSHIP4003", "멤버십 번호는 숫자만 입력 가능합니다."),
+    MEMBERSHIP4004(HttpStatus.BAD_REQUEST, "MEMBERSHIP4004", "멤버십 번호는 최소 12자 이상이어야 합니다."),
+    MEMBERSHIP4005(HttpStatus.CONFLICT, "MEMBERSHIP4005", "이미 저장된 멤버십 브랜드입니다."),
 
     // ========== 바코드 에러 (BARCODE) ==========
     BARCODE4001(HttpStatus.BAD_REQUEST, "BARCODE4001", "지원하지 않는 바코드 형식입니다.");


### PR DESCRIPTION
## #️⃣ 기능 설명
> 사용자가 멤버십 브랜드를 선택하고 멤버십 번호를 직접 입력하여 등록하는 API를 구현
> 프론트에서 바코드 문자열을 추출하여 함께 전달

## 🛠️ 작업 상세 내용
- [x] POST /{membershipBrandId}/number 등록 엔드포인트 구현
- [x] 멤버십 번호 유효성 검사 (빈값/숫자만/최소 12자/최대 20자)
- [x] 브랜드 존재 여부 및 중복 등록 체크
- [x] Request DTO, Response DTO, Converter, Repository, CommandService 구현

## 📸 스크린샷 (선택)
- 멤버십 등록 성공
<img width="479" height="858" alt="스크린샷 2026-01-31 오후 10 18 14" src="https://github.com/user-attachments/assets/7c918c72-6f98-40c0-a81b-abf142dcc249" />


- 중복 저장 시 실패
<img width="584" height="821" alt="스크린샷 2026-01-31 오후 10 41 58" src="https://github.com/user-attachments/assets/899c4423-9e80-4114-8218-3e09c5457110" />


- 숫자 외 입력 시 실패
<img width="498" height="820" alt="스크린샷 2026-01-31 오후 10 42 28" src="https://github.com/user-attachments/assets/c40a059a-0015-4ffc-8de2-550c77c36def" />


- 번호 12자 이하 입력 시 실패
<img width="529" height="821" alt="스크린샷 2026-01-31 오후 10 42 11" src="https://github.com/user-attachments/assets/9d430d19-e648-47c2-9732-86e540af47c4" />


- 번호 20자 이상 입력 시 실패
<img width="524" height="822" alt="스크린샷 2026-01-31 오후 10 42 42" src="https://github.com/user-attachments/assets/b3693af6-438f-4d7b-bfb2-62829fa88b66" />


## 💬 기타(공유사항 to 리뷰어)
- userId는 현재 쿼리파라미터로 받고 있으며, 추후 JWT 인증으로 변경 예정입니다