### PR TITLE
♻️ [Refactor] 개인정보 조회 API(JWT 인증 적용)

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -49,12 +49,11 @@ public class UserController implements UserControllerDocs{
     }
 
     // 개인정보 조회 API
-    @GetMapping("/users") // TODO: 추후 "/users/me"로 수정
+    @GetMapping("/users/me")
     public ApiResponse<UserResponseDto.PersonalInfoResponseDto> getPersonalInfo(
-            //@AuthenticationPrincipal CustomUserDetails userDetails
-            @RequestParam Long userId  // TODO: 추후 JWT에서 추출
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        //Long userId = userDetails.getUserId();
+        Long userId = userDetails.getUserId();
         UserResponseDto.PersonalInfoResponseDto response = userQueryService.getPersonalInfo(userId);
         return ApiResponse.onSuccess(UserSuccessCode.PERSONAL_INFO_OK, response);
     }

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -3,12 +3,12 @@ package com.umc.barkit.domain.user.controller;
 import com.umc.barkit.domain.user.dto.req.UserRequestDto;
 import com.umc.barkit.domain.user.dto.res.UserResponseDto;
 import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 
 public interface UserControllerDocs {
 
@@ -50,15 +50,13 @@ public interface UserControllerDocs {
     @Operation(
             summary = "개인정보 조회 API",
             description = "개인정보 변경 페이지 진입 시, 사용자 개인정보(이름/이메일/전화번호/생년월일)를 조회합니다.<br>" +
-                    "현재는 테스트 편의를 위해 userId를 쿼리 파라미터로 받습니다.<br>" +
-                    "추후 JWT 인증 적용 시, 토큰에서 userId를 추출하는 방식(/api/users/me)으로 변경 예정입니다."
+                    "JWT 인증 방식으로 동작하며, Authorization 헤더의 Access Token에서 사용자 정보를 식별합니다.<br>"
     )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자가 존재하지 않음")
     })
     ApiResponse<UserResponseDto.PersonalInfoResponseDto> getPersonalInfo(
-            @Parameter(description = "사용자 ID", required = true, example = "100")
-            @RequestParam Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     );
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
쿼리 파라미터 userId 방식 → JWT 기반 인증 방식으로 전환

## 🛠️ 작업 상세 내용
- [x] JWT 기반 인증 방식으로 전환

## 📸 스크린샷 (선택)
* 개인정보 조회 성공(JWT 인증)
<img width="600" height="550" alt="image" src="https://github.com/user-attachments/assets/2b8c5a79-0213-4c5e-939e-0c1b3bec1f8b" />


## 💬 기타(공유사항 to 리뷰어)