### PR TITLE
✨ [Feat] 생년월일 변경 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -12,10 +12,10 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -36,7 +36,7 @@ public class UserController implements UserControllerDocs{
     // 회원가입 API
     @PostMapping("/auth/signup")
     public ApiResponse<UserResponseDto.SignupResponseDto> signup(@RequestBody @Valid UserRequestDto.SignupRequestDto signupRequestDto) {
-        UserResponseDto.SignupResponseDto response = userCommandService.Signup(signupRequestDto);
+        UserResponseDto.SignupResponseDto response = userCommandService.signup(signupRequestDto);
         return ApiResponse.onSuccess(UserSuccessCode.CREATED, response);
     }
 
@@ -58,6 +58,18 @@ public class UserController implements UserControllerDocs{
         return ApiResponse.onSuccess(UserSuccessCode.PERSONAL_INFO_OK, response);
     }
 
+
+    // 생년월일 변경 API
+    @PatchMapping("/users/me/birth-date")
+    public ApiResponse<UserResponseDto.PersonalInfoResponseDto> updateBirthDate(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserRequestDto.UpdateBirthDateRequestDto birthDateDto
+    ){
+        Long userId = userDetails.getUserId();
+        userCommandService.updateBirthDate(userId, birthDateDto.birthDate());
+        UserResponseDto.PersonalInfoResponseDto response = userQueryService.getPersonalInfo(userId);
+        return ApiResponse.onSuccess(UserSuccessCode.BIRTH_DATE_UPDATED, response);
+    }
 
 
 

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -59,4 +59,18 @@ public interface UserControllerDocs {
     ApiResponse<UserResponseDto.PersonalInfoResponseDto> getPersonalInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails
     );
+
+
+    @Operation(
+            summary = "생년월일 변경 API",
+            description = "개인정보 변경 페이지에서 사용자의 생년월일을 변경합니다.<br>" +
+                    "JWT 인증 방식으로 동작하며, Authorization 헤더의 Access Token에서 사용자 정보를 식별합니다.<br>"
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "변경 성공")
+    })
+    ApiResponse<UserResponseDto.PersonalInfoResponseDto> updateBirthDate(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserRequestDto.UpdateBirthDateRequestDto request
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -1,10 +1,14 @@
 package com.umc.barkit.domain.user.dto.req;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
+import java.time.LocalDate;
 import java.util.List;
 
 public class UserRequestDto {
@@ -44,4 +48,14 @@ public class UserRequestDto {
             @NotBlank
             String password
     ){}
+
+    // 생년월일 변경
+    public record UpdateBirthDateRequestDto(
+            @NotNull
+            @PastOrPresent
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+            @Schema(example = "2003-05-19")
+            LocalDate birthDate
+    ) {
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/user/entity/User.java
+++ b/src/main/java/com/umc/barkit/domain/user/entity/User.java
@@ -50,4 +50,9 @@ public class User extends BaseEntity {
         this.deletedAt = LocalDateTime.now();
         this.status = UserStatus.INACTIVE;
     }
+
+    // 생년월일 변경
+    public void updateBirthDate(LocalDate birthDate) {
+        this.birthDate = birthDate;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
@@ -7,13 +7,18 @@ import com.umc.barkit.domain.user.entity.Term;
 import com.umc.barkit.domain.user.entity.User;
 import com.umc.barkit.domain.user.entity.mapping.UserTerm;
 import com.umc.barkit.domain.user.enums.Role;
+import com.umc.barkit.domain.user.exception.UserException;
+import com.umc.barkit.domain.user.exception.code.UserErrorCode;
 import com.umc.barkit.domain.user.repository.TermRepository;
 import com.umc.barkit.domain.user.repository.UserRepository;
 import com.umc.barkit.domain.user.repository.UserTermRepository;
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,16 +30,17 @@ public class UserCommandService {
     private final BCryptPasswordEncoder passwordEncoder;
 
     // 회원가입
-    public UserResponseDto.SignupResponseDto Signup(UserRequestDto.SignupRequestDto signupRequestDto){
+    @Transactional
+    public UserResponseDto.SignupResponseDto signup(UserRequestDto.SignupRequestDto signupRequestDto){
 
         // 이메일 중복 확인
         if (userRepository.existsByEmail(signupRequestDto.email())) {
-            throw new IllegalArgumentException("이미 등록된 이메일입니다");
+            throw new UserException(UserErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
         // 비밀번호 확인
         if(!signupRequestDto.password().equals(signupRequestDto.confirmPassword())){
-            throw new IllegalArgumentException("비밀번호와 비밀번호 확인이 일치하지 않습니다");
+            throw new UserException(UserErrorCode.PASSWORD_MISMATCH);
         }
 
         // 비밀번호 암호화
@@ -55,5 +61,14 @@ public class UserCommandService {
 
         // DTO 응답
         return new UserResponseDto.SignupResponseDto(user.getId(), user.getEmail());
+    }
+
+    // 생년월일 변경
+    @Transactional
+    public void updateBirthDate(Long userId, LocalDate birthDate){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        user.updateBirthDate(birthDate);
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
PATCH /users/me/birth-date 요청 시 생년월일을 업데이트하고, 변경된 사용자 정보를 PersonalInfoResponseDto로 반환합니다.

## 🛠️ 작업 상세 내용
- [x] 생년월일 변경 API 추가
- [x] UpdateBirthDateRequestDto 추가 및 Validation 적용 (@NotNull, @PastOrPresent, 날짜 포맷)

## 📸 스크린샷 (선택)
* 생년월일 변경 전 개인정보 조회
<img width="550" height="250" alt="image" src="https://github.com/user-attachments/assets/5a5223d4-4706-4e7c-b1cd-0b5b0730463b" />

* 생년월일 변경 성공
<img width="550" height="450" alt="image" src="https://github.com/user-attachments/assets/6842d015-4882-44fc-a0f5-706a4d81bf1d" />
<img width="550" height="250" alt="image" src="https://github.com/user-attachments/assets/c5f33e8b-a619-416a-be7a-5ea8e6a3b869" />

* 생년월일 변경 후 개인정보 조회
<img width="550" height="450" alt="image" src="https://github.com/user-attachments/assets/70689cf5-a95f-4110-83a1-57efd3516d6d" />


## 💬 기타(공유사항 to 리뷰어)