### PR TITLE
♻️ [refactor] 스레드풀 활용을 통한 지도 검색 api 성능 개선 

### DIFF
--- a/src/main/java/com/umc/barkit/domain/store/controller/StoreController.java
+++ b/src/main/java/com/umc/barkit/domain/store/controller/StoreController.java
@@ -11,12 +11,15 @@ import com.umc.barkit.domain.store.exception.code.StoreSuccessCode;
 import com.umc.barkit.domain.store.service.query.StoreQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
+@Slf4j
 public class StoreController implements StoreControllerDocs{
 
     private final StoreQueryService storeQueryService;
@@ -30,6 +33,7 @@ public class StoreController implements StoreControllerDocs{
             int cursor,
             int size
     ) {
+        LocalDateTime startTime = LocalDateTime.now();
         if (distanceType == DistanceType.CENTER && (req.centerLat() == null || req.centerLng() == null)) {
             throw new StoreException(StoreErrorCode.CENTER_LOCATION_REQUIRED);
         }
@@ -40,7 +44,6 @@ public class StoreController implements StoreControllerDocs{
                 code,
                 storeQueryService.search(req, distanceType, category, sort, cursor, size)
         );
-
     }
 
     @Override

--- a/src/main/java/com/umc/barkit/domain/store/dto/google/GooglePlaceDTO.java
+++ b/src/main/java/com/umc/barkit/domain/store/dto/google/GooglePlaceDTO.java
@@ -1,6 +1,8 @@
 package com.umc.barkit.domain.store.dto.google;
 
 import java.util.List;
+
+import com.umc.barkit.domain.store.external.google.dto.GoogleResDTO;
 import lombok.Builder;
 
 public class GooglePlaceDTO {
@@ -37,4 +39,9 @@ public class GooglePlaceDTO {
             Integer widthPx,
             Integer heightPx
     ) {}
+
+    public record BrandPlacesResult(
+            Long storeBrandId,
+            String storeName,
+            List<GoogleResDTO.Place> places) {}
 }

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandMembershipBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandMembershipBrandRepository.java
@@ -1,8 +1,10 @@
 package com.umc.barkit.domain.store.repository;
 
 import com.umc.barkit.domain.store.entity.mapping.StoreBrandMembershipBrand;
+import com.umc.barkit.domain.store.repository.projection.BrandMembershipProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -23,4 +25,19 @@ public interface StoreBrandMembershipBrandRepository extends JpaRepository<Store
     List<Long> findMembershipBrandIdsByStoreBrandId(Long storeBrandId);
 
     List<StoreBrandMembershipBrand> findByStoreBrandId(Long storeBrandId);
+
+    //여러 브랜드의 멤버십 정보를 한 번에 가져오기
+    @Query("""
+        select
+            sbmb.storeBrand.id as storeBrandId,
+            mb.id as membershipId,
+            mb.name as membershipName,
+            mb.logoUrl as membershipLogoUrl
+        from StoreBrandMembershipBrand sbmb
+        join sbmb.membershipBrand mb
+        where sbmb.storeBrand.id in :storeBrandIds
+    """)
+    List<BrandMembershipProjection> findMembershipsByStoreBrandIds(
+            List<Long> storeBrandIds
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandRepository.java
@@ -2,10 +2,13 @@ package com.umc.barkit.domain.store.repository;
 
 import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.domain.store.enums.Category;
+import com.umc.barkit.domain.store.repository.projection.BrandIdNameProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -19,12 +22,17 @@ public interface StoreBrandRepository extends JpaRepository<StoreBrand,Long> {
     String findNameById(Long storeBrandId);
 
     //카테고리 조회
+    // ✅ 카테고리 필터 + id,name 한방에 가져오기 (N+1 제거)
     @Query(
-            "select sb.name " +
+            "select sb.id as id, sb.name as name " +
                     "from StoreBrand sb " +
-                    "where sb.id = :storeBrandId and sb.category = :category"
-    )
-    Optional<String> findNameByIdAndCategory(Long storeBrandId, Category category);
+                    "where sb.id in :ids " +
+                    "and (:category = com.umc.barkit.domain.store.enums.Category.ALL or sb.category = :category)"
+            )
+    List<BrandIdNameProjection> findIdNameByIdsAndCategory(
+            @Param("ids") List<Long> ids,
+            @Param("category") Category category
+    );
 
     //매장명 존재 여부 조회
     @Query(

--- a/src/main/java/com/umc/barkit/domain/store/repository/projection/BrandIdNameProjection.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/projection/BrandIdNameProjection.java
@@ -1,0 +1,6 @@
+package com.umc.barkit.domain.store.repository.projection;
+
+public interface BrandIdNameProjection {
+    Long getId();
+    String getName();
+}

--- a/src/main/java/com/umc/barkit/domain/store/repository/projection/BrandMembershipProjection.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/projection/BrandMembershipProjection.java
@@ -1,0 +1,8 @@
+package com.umc.barkit.domain.store.repository.projection;
+
+public interface BrandMembershipProjection {
+    Long getStoreBrandId();
+    Long getMembershipId();
+    String getMembershipName();
+    String getMembershipLogoUrl();
+}

--- a/src/main/java/com/umc/barkit/domain/store/service/command/StoreCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/command/StoreCommandService.java
@@ -1,0 +1,20 @@
+package com.umc.barkit.domain.store.service.command;
+
+import com.umc.barkit.domain.store.dto.res.StoreResDTO;
+import com.umc.barkit.domain.store.entity.StoreBrand;
+import com.umc.barkit.domain.store.external.google.dto.GoogleResDTO;
+
+import java.util.List;
+
+public interface StoreCommandService {
+    List<StoreResDTO.SearchedStore> saveAndMap(
+            StoreBrand storeBrand,
+            List<GoogleResDTO.Place> places,
+            Double userLat,
+            Double userLng,
+            Double sendLat,
+            Double sendLng,
+            boolean applyDistanceFilter,
+            List<StoreResDTO.SearchedStoreMembership> membershipsDTO
+    );
+}

--- a/src/main/java/com/umc/barkit/domain/store/service/command/StoreCommandServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/command/StoreCommandServiceImpl.java
@@ -1,0 +1,127 @@
+package com.umc.barkit.domain.store.service.command;
+
+import com.umc.barkit.domain.store.dto.res.StoreResDTO;
+import com.umc.barkit.domain.store.entity.Store;
+import com.umc.barkit.domain.store.entity.StoreBrand;
+import com.umc.barkit.domain.store.external.google.dto.GoogleResDTO;
+import com.umc.barkit.domain.store.repository.StoreRepository;
+import com.umc.barkit.domain.store.util.StoreUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StoreCommandServiceImpl implements StoreCommandService{
+
+    private final StoreRepository storeRepository;
+    private final StoreUtil storeUtil;
+
+    private static final double MAX_DISTANCE_KM = 5.0;
+
+    @Override
+    public List<StoreResDTO.SearchedStore> saveAndMap(
+            StoreBrand storeBrand,
+            List<GoogleResDTO.Place> places,
+            Double userLat,
+            Double userLng,
+            Double sendLat,
+            Double sendLng,
+            boolean applyDistanceFilter,
+            List<StoreResDTO.SearchedStoreMembership> membershipsDTO
+    ) {
+        if (places == null || places.isEmpty()) return List.of();
+        if (storeBrand == null) return List.of();
+
+        // placeId 중복 제거 + location 없는 데이터 제거
+        Map<String, GoogleResDTO.Place> uniquePlacesById = new LinkedHashMap<>();
+        for (GoogleResDTO.Place p : places) {
+            if (p == null || p.id() == null) continue;
+            if (p.location() == null) continue;
+            uniquePlacesById.putIfAbsent(p.id(), p);
+        }
+        if (uniquePlacesById.isEmpty()) return List.of();
+
+        List<String> googleIds = new ArrayList<>(uniquePlacesById.keySet());
+
+        // 기존 store 한 번에 조회
+        Map<String, Store> existingByGoogleId =
+                storeRepository.findAllByGoogleIdIn(googleIds).stream()
+                        .collect(Collectors.toMap(Store::getGoogleId, Function.identity()));
+
+        // 없는 것만 모아 saveAll
+        List<Store> toSave = new ArrayList<>();
+        for (String gid : googleIds) {
+            if (!existingByGoogleId.containsKey(gid)) {
+                toSave.add(Store.builder()
+                        .googleId(gid)
+                        .brand(storeBrand)
+                        .build());
+            }
+        }
+
+        if (!toSave.isEmpty()) {
+            List<Store> saved = storeRepository.saveAll(toSave);
+            for (Store s : saved) {
+                existingByGoogleId.put(s.getGoogleId(), s);
+            }
+        }
+
+        // DTO 매핑 + 거리 필터
+        List<StoreResDTO.SearchedStore> result = new ArrayList<>();
+        for (String gid : googleIds) {
+            GoogleResDTO.Place p = uniquePlacesById.get(gid);
+            Store store = existingByGoogleId.get(gid);
+            if (p == null || store == null) continue;
+
+            double storeLat = p.location().latitude();
+            double storeLng = p.location().longitude();
+
+            if (applyDistanceFilter) {
+                double distKmFromSendPoint = storeUtil.distanceKm(sendLat, sendLng, storeLat, storeLng);
+                if (distKmFromSendPoint > MAX_DISTANCE_KM) continue;
+            }
+
+            result.add(mapToSearchedStore(p, store.getId(), membershipsDTO, userLat, userLng));
+        }
+
+        return result;
+    }
+
+    private StoreResDTO.SearchedStore mapToSearchedStore(
+            GoogleResDTO.Place p,
+            Long storeId,
+            List<StoreResDTO.SearchedStoreMembership> memberships,
+            Double userLat,
+            Double userLng
+    ) {
+        double storeLat = p.location().latitude();
+        double storeLng = p.location().longitude();
+
+        Double distanceKm = storeUtil.round2(storeUtil.distanceKm(userLat, userLng, storeLat, storeLng));
+        String directionUrl = storeUtil.buildGoogleDirectionUrl(p.id(), storeLat, storeLng);
+
+        return StoreResDTO.SearchedStore.builder()
+                .storeId(storeId)
+                .googleId(p.id())
+                .name(p.displayName())
+                .location(StoreResDTO.SearchedStoreLocation.builder()
+                        .lat(storeLat)
+                        .lng(storeLng)
+                        .build())
+                .address(p.formattedAddress())
+                .phone(p.nationalPhoneNumber())
+                .memberships(memberships)
+                .distanceKm(distanceKm)
+                .directionUrl(directionUrl)
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
@@ -18,28 +18,45 @@ import com.umc.barkit.domain.store.external.google.dto.GoogleResDTO;
 import com.umc.barkit.domain.store.repository.StoreBrandMembershipBrandRepository;
 import com.umc.barkit.domain.store.repository.StoreBrandRepository;
 import com.umc.barkit.domain.store.repository.StoreRepository;
+import com.umc.barkit.domain.store.repository.projection.BrandIdNameProjection;
+import com.umc.barkit.domain.store.repository.projection.BrandMembershipProjection;
 import com.umc.barkit.domain.store.repository.projection.ViewCountProjection;
+import com.umc.barkit.domain.store.service.command.StoreCommandService;
+import com.umc.barkit.domain.store.util.StoreUtil;
 import lombok.RequiredArgsConstructor;
 
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.*;
-import java.util.function.Function;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class StoreQueryServiceImpl implements StoreQueryService{
-    private final MembershipBrandRepository membershipBrandRepository;
 
+    private final MembershipBrandRepository membershipBrandRepository;
     private final StoreBrandMembershipBrandRepository storeBrandMembershipBrandRepository;
     private final StoreRepository storeRepository;
     private final StoreBrandRepository storeBrandRepository;
+
     private final GoogleMapSearchClient googleClient;
+    private final StoreCommandService storeCommandService;
+
+    private final StoreUtil storeUtil;
 
     private static final double MAX_DISTANCE_KM = 5.0;
+
+    @Qualifier("googleSearchExecutor")
+    private final Executor googleSearchExecutor;
 
     //목록 조회(멤버십/매장)
     @Override
@@ -51,6 +68,8 @@ public class StoreQueryServiceImpl implements StoreQueryService{
             int cursor,
             int size
     ) {
+
+        long t0 = System.nanoTime();
 
         List<StoreResDTO.SearchedStore> fullResult;
 
@@ -96,6 +115,10 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         boolean hasNext = to < deduped.size();
         int nextCursor = to;
 
+
+        long elapsedMs = (System.nanoTime() - t0) / 1_000_000;
+        log.info("소요 시간 : " + elapsedMs);
+
         return new StoreResDTO.SearchedStoreSlice(page, hasNext, nextCursor);
 
     }
@@ -124,7 +147,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
                 .lng(storeLng)
                 .build();
 
-        double distance = round2(distanceKm(userLat, userLng, storeLat, storeLng));
+        double distance = storeUtil.round2(storeUtil.distanceKm(userLat, userLng, storeLat, storeLng));
 
         // 영업시간 정보
         boolean isOpen = g.currentOpeningHours() != null && g.currentOpeningHours().openNow();
@@ -302,16 +325,21 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         List<GoogleResDTO.Place> places = googleClient.searchText(query, sendLat, sendLng);
         if (places == null || places.isEmpty()) return List.of();
 
+        List<StoreResDTO.SearchedStoreMembership> membershipsDTO =
+                findMembershipsForStoreBrand(matchedBrand.getId());
+
         // 검색 반경 5km 필터 적용
-        return saveStoreAndReturnResDTO(
-                matchedBrand.getId(),
+        return storeCommandService.saveAndMap(
+                matchedBrand,
                 places,
                 userLat,
                 userLng,
                 sendLat,
                 sendLng,
-                true
+                true,
+                membershipsDTO
         );
+
     }
 
     // 전체 검색
@@ -325,15 +353,19 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         List<GoogleResDTO.Place> places = googleClient.searchText(query);
         if (places == null || places.isEmpty()) return List.of();
 
+        List<StoreResDTO.SearchedStoreMembership> membershipsDTO =
+                findMembershipsForStoreBrand(matchedBrand.getId());
+
         // 검색 반경 5km 필터 미적용
-        return saveStoreAndReturnResDTO(
-                matchedBrand.getId(),
+        return storeCommandService.saveAndMap(
+                matchedBrand,
                 places,
                 userLat,
                 userLng,
                 userLat,
                 userLng,
-                false
+                false,
+                membershipsDTO
         );
     }
 
@@ -353,133 +385,97 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         List<Long> storeBrandIds =
                 storeBrandMembershipBrandRepository.findStoreBrandIdsByMembershipBrandId(membership.get().getId());
 
-        List<String> storeNames = new ArrayList<>();
-        List<Long> filteredStoreBrandIds = new ArrayList<>();
-        List<StoreResDTO.SearchedStore> result = new ArrayList<>();
+        if (storeBrandIds == null || storeBrandIds.isEmpty()) return List.of();
 
-        //카테고리 구분
-        categoryChecking(category, storeBrandIds, storeNames, filteredStoreBrandIds);
+        // 카테고리 필터링 (IN 절 사용해서 한번에 조회)
+        List<BrandIdNameProjection> idNames =
+                storeBrandRepository.findIdNameByIdsAndCategory(storeBrandIds, category);
 
-        /*카테고리 구분 후 일치하는 겁색결과가 없어서
-        storeNames, filteredStoreBrandIds 빈 리스트 일 때*/
-        if (storeNames.isEmpty() && filteredStoreBrandIds.isEmpty()) {
-            return result;
-        }
+        // 매칭되는 카테고리 없으면 빈 리스트 반환
+        if (idNames == null || idNames.isEmpty()) return List.of();
 
-        //외부 API 호출 및 Store 저장
+        List<Long> filteredBrandIds = idNames.stream().map(BrandIdNameProjection::getId).toList();
+        List<String> storeNames = idNames.stream().map(BrandIdNameProjection::getName).toList();
+
+        // StoreBrand도 한번에 가져오기
+        Map<Long, StoreBrand> storeBrandMap =
+                storeBrandRepository.findAllById(filteredBrandIds).stream()
+                        .collect(Collectors.toMap(StoreBrand::getId, sb -> sb));
+
+        // 멤버십 DTO도 한 번에 가져오기
+        Map<Long, List<StoreResDTO.SearchedStoreMembership>> membershipsByBrandId =
+                preloadMembershipsDTO(filteredBrandIds);
+
+        // 구글 api 호출 시 기준이 될 위도, 경도 정하기
+        Double sendLat = (distanceType == DistanceType.CURRENT) ? userLat : centerLat;
+        Double sendLng = (distanceType == DistanceType.CURRENT) ? userLng : centerLng;
+
+        // 구글 api 호출 병렬 처리
+        List<CompletableFuture<GooglePlaceDTO.BrandPlacesResult>> futures = new ArrayList<>();
+
         for (int i = 0; i < storeNames.size(); i++) {
             String storeName = storeNames.get(i);
-            Long storeBrandId = filteredStoreBrandIds.get(i);
+            Long storeBrandId = filteredBrandIds.get(i);
 
-            Double sendLat = (distanceType == DistanceType.CURRENT) ? userLat : centerLat;
-            Double sendLng = (distanceType == DistanceType.CURRENT) ? userLng : centerLng;
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                        List<GoogleResDTO.Place> places = googleClient.searchText(storeName, sendLat, sendLng);
+                        return new GooglePlaceDTO.BrandPlacesResult(storeBrandId, storeName, places);
+                    }, googleSearchExecutor)
+                    .orTimeout(3, TimeUnit.SECONDS)
+                    .exceptionally(ex -> new GooglePlaceDTO.BrandPlacesResult(storeBrandId, storeName, List.of())));
+        }
 
-            //매장명으로 구글 API 호출
-            List<GoogleResDTO.Place> places = googleClient.searchText(storeName, sendLat, sendLng);
+        List<GooglePlaceDTO.BrandPlacesResult> brandResults = futures.stream()
+                .map(CompletableFuture::join)
+                .toList();
 
-            // store 저장 + StoreResDTO 매핑해서 결과에 합치기
-            result.addAll(saveStoreAndReturnResDTO(
-                    storeBrandId, places, userLat, userLng, sendLat, sendLng, true
+
+        List<StoreResDTO.SearchedStore> result = new ArrayList<>();
+
+        // api 호출 결과로 가져온 매장 db에 없으면 저장
+        for (GooglePlaceDTO.BrandPlacesResult r : brandResults) {
+            if (r.places() == null || r.places().isEmpty()) continue;
+
+            StoreBrand sb = storeBrandMap.get(r.storeBrandId());
+            if (sb == null) continue;
+
+            List<StoreResDTO.SearchedStoreMembership> membershipsDTO =
+                    membershipsByBrandId.getOrDefault(r.storeBrandId(), List.of());
+
+            result.addAll(storeCommandService.saveAndMap(
+                    sb,
+                    r.places(),
+                    userLat,
+                    userLng,
+                    sendLat,
+                    sendLng,
+                    true,
+                    membershipsDTO
             ));
         }
 
         return result;
     }
 
-    //카테고리 구분 메서드
-    private void categoryChecking(Category category, List<Long> storeBrandIds, List<String> storeNames, List<Long> filteredStoreBrandIds) {
-        if (category != Category.ALL) {
-            for (Long storeBrandId : storeBrandIds) {
-                Optional<String> storeName = storeBrandRepository.findNameByIdAndCategory(storeBrandId, category);
-                if (storeName.isPresent()) {
-                    storeNames.add(storeName.get());
-                    filteredStoreBrandIds.add(storeBrandId);
-                } else {
-                    continue;
-                }
-            }
-        } else if (category == Category.ALL) {
-            for (Long storeBrandId : storeBrandIds) {
-                storeNames.add(storeBrandRepository.findNameById(storeBrandId));
-                filteredStoreBrandIds.add(storeBrandId);
-            }
+
+    private Map<Long, List<StoreResDTO.SearchedStoreMembership>> preloadMembershipsDTO(List<Long> storeBrandIds) {
+        List<BrandMembershipProjection> rows =
+                storeBrandMembershipBrandRepository.findMembershipsByStoreBrandIds(storeBrandIds);
+
+        if (rows == null || rows.isEmpty()) return Map.of();
+
+        Map<Long, List<StoreResDTO.SearchedStoreMembership>> map = new HashMap<>();
+        for (BrandMembershipProjection r : rows) {
+            map.computeIfAbsent(r.getStoreBrandId(), k -> new ArrayList<>())
+                    .add(StoreResDTO.SearchedStoreMembership.builder()
+                            .id(r.getMembershipId())
+                            .name(r.getMembershipName())
+                            .logoUrl(r.getMembershipLogoUrl())
+                            .build());
         }
+        return map;
     }
 
-    private List<StoreResDTO.SearchedStore> saveStoreAndReturnResDTO(
-            Long storeBrandId,
-            List<GoogleResDTO.Place> places,
-            Double userLat,
-            Double userLng,
-            Double sendLat,
-            Double sendLng,
-            boolean applyDistanceFilter
-    ) {
-        if (places == null || places.isEmpty()) return List.of();
-
-        StoreBrand storeBrand = storeBrandRepository.findById(storeBrandId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 store_brand"));
-
-        List<StoreResDTO.SearchedStoreMembership> membershipsDTO = findMembershipsForStoreBrand(storeBrandId);
-
-        Map<String, GoogleResDTO.Place> uniquePlacesById = new LinkedHashMap<>();
-
-        for (GoogleResDTO.Place p : places) {
-            if (p == null || p.id() == null) continue;
-
-            if (p.location() == null) continue;
-
-            uniquePlacesById.putIfAbsent(p.id(), p);
-        }
-
-        if (uniquePlacesById.isEmpty()) return List.of();
-
-        List<String> googleIds = new ArrayList<>(uniquePlacesById.keySet());
-
-        Map<String, Store> existingByGoogleId =
-                storeRepository.findAllByGoogleIdIn(googleIds).stream()
-                        .collect(Collectors.toMap(Store::getGoogleId, Function.identity()));
-
-        // DB에 없는 googleId만 모아서 한 번에 저장
-        List<Store> toSave = new ArrayList<>();
-        for (String gid : googleIds) {
-            if (!existingByGoogleId.containsKey(gid)) {
-                toSave.add(Store.builder()
-                        .googleId(gid)
-                        .brand(storeBrand)
-                        .build());
-            }
-        }
-
-        if (!toSave.isEmpty()) {
-            List<Store> saved = storeRepository.saveAll(toSave);
-            for (Store s : saved) {
-                existingByGoogleId.put(s.getGoogleId(), s);
-            }
-        }
-
-
-        List<StoreResDTO.SearchedStore> result = new ArrayList<>();
-
-        for (String gid : googleIds) {
-            GoogleResDTO.Place p = uniquePlacesById.get(gid);
-            Store store = existingByGoogleId.get(gid);
-            if (p == null || store == null) continue;
-
-            double storeLat = p.location().latitude();
-            double storeLng = p.location().longitude();
-
-            if (applyDistanceFilter) {
-                double distKmFromSendPoint = distanceKm(sendLat, sendLng, storeLat, storeLng);
-                if (distKmFromSendPoint > MAX_DISTANCE_KM) continue;
-            }
-
-            result.add(mapToSearchedStore(p, store.getId(), membershipsDTO, userLat, userLng));
-
-        }
-
-        return result;
-    }
 
     private List<StoreResDTO.SearchedStoreMembership> findMembershipsForStoreBrand(Long storeBrandId) {
         List<Long> membershipIds =
@@ -496,69 +492,8 @@ public class StoreQueryServiceImpl implements StoreQueryService{
                 .map(m -> StoreResDTO.SearchedStoreMembership.builder()
                         .id(m.getId())
                         .name(m.getName())
-                        .logoUrl(m.getLogoUrl()) // MembershipBrand에 logoUrl 필드가 있다고 가정
+                        .logoUrl(m.getLogoUrl())
                         .build())
                 .toList();
     }
-
-    //응답 DTO 매핑
-    private StoreResDTO.SearchedStore mapToSearchedStore(
-            GoogleResDTO.Place p,
-            Long storeId,
-            List<StoreResDTO.SearchedStoreMembership> memberships,
-            Double userLat,
-            Double userLng
-    ) {
-        double storeLat = p.location().latitude();
-        double storeLng = p.location().longitude();
-
-        Double distanceKm = round2(distanceKm(userLat, userLng, storeLat, storeLng));
-
-        //일단 구글 길찾기로
-        String directionUrl = buildGoogleDirectionUrl(p.id(), storeLat, storeLng);
-
-
-        return StoreResDTO.SearchedStore.builder()
-                .storeId(storeId)
-                .googleId(p.id())
-                .name(p.displayName())
-                .location(StoreResDTO.SearchedStoreLocation.builder()
-                        .lat(storeLat)
-                        .lng(storeLng)
-                        .build())
-                .address(p.formattedAddress())
-                .phone(p.nationalPhoneNumber())
-                .memberships(memberships)
-                .distanceKm(distanceKm)
-                .directionUrl(directionUrl)
-                .build();
-    }
-
-    //구글 길찾기 url
-    private String buildGoogleDirectionUrl(String placeId, double lat, double lng) {
-        return "https://www.google.com/maps/dir/?api=1"
-                + "&destination=" + lat + "," + lng
-                + "&destination_place_id=" + java.net.URLEncoder.encode(placeId, java.nio.charset.StandardCharsets.UTF_8);
-    }
-
-    private double round2(double v) {
-        return Math.round(v * 100) / 100.0;
-    }
-
-    private static final double EARTH_RADIUS_KM = 6371.0;
-
-    //위도, 경도로 사용자 현재위치와 매장 사이의 거리 계산
-    private double distanceKm(double lat1, double lng1, double lat2, double lng2) {
-        double dLat = Math.toRadians(lat2 - lat1);
-        double dLng = Math.toRadians(lng2 - lng1);
-
-        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
-                + Math.cos(Math.toRadians(lat1))
-                * Math.cos(Math.toRadians(lat2))
-                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
-
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-        return EARTH_RADIUS_KM * c;
-    }
-
 }

--- a/src/main/java/com/umc/barkit/domain/store/util/StoreUtil.java
+++ b/src/main/java/com/umc/barkit/domain/store/util/StoreUtil.java
@@ -1,0 +1,34 @@
+package com.umc.barkit.domain.store.util;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class StoreUtil {
+
+    private static final double EARTH_RADIUS_KM = 6371.0;
+
+    public double round2(double v) {
+        return Math.round(v * 100) / 100.0;
+    }
+
+    //위도, 경도로 사용자 현재위치와 매장 사이의 거리 계산
+    public double distanceKm(double lat1, double lng1, double lat2, double lng2) {
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLng = Math.toRadians(lng2 - lng1);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2)
+                + Math.cos(Math.toRadians(lat1))
+                * Math.cos(Math.toRadians(lat2))
+                * Math.sin(dLng / 2) * Math.sin(dLng / 2);
+
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return EARTH_RADIUS_KM * c;
+    }
+
+    //구글 길찾기 url 반환
+    public String buildGoogleDirectionUrl(String placeId, double lat, double lng) {
+        return "https://www.google.com/maps/dir/?api=1"
+                + "&destination=" + lat + "," + lng
+                + "&destination_place_id=" + java.net.URLEncoder.encode(placeId, java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/umc/barkit/global/config/AsyncConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package com.umc.barkit.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "googleSearchExecutor")
+    public Executor apiExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(16);
+        executor.setMaxPoolSize(32);
+        executor.setQueueCapacity(300);
+        executor.setThreadNamePrefix("google-search-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.initialize();
+        return executor;
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
지도 검색 api 성능 개선을 위하여 스레드풀을 사용하여 병렬 처리가 가능하도록 수정하였습니다.

## 🛠️ 작업 상세 내용
### 스레드풀 사용하여 병렬처리 적용
- [x] `AsyncConfig` 클래스 생성(기본 스레드 수 : 16,  최대 스레드 수 : 32)

### 기타 수정 사항
- [x] 카테고리 조회 쿼리 수정 기존 반목분 사용을 통한 개별 조회 -> 한번에 조회 (IN 절 사용) 
- [x] `StoreBrand` 엔티티 조회도 `findAllById()` 매서드로 한번에 조회
- [x] `Store`엔티티 저장 로직 `StoreCommandService` 에 따로 분리 
- [x] 사용자 위치로부터 매장까지의 거리 계산, 구글 길찾기 url 반환 로직 `StoreUtil` 클래스에 따로 분리


## 📸 스크린샷 (선택)
1. 최초 조회
<img width="1870" height="544" alt="스크린샷 2026-02-02 200341" src="https://github.com/user-attachments/assets/99ef0498-19b5-449e-9258-a613a1461a03" />
<img width="1850" height="632" alt="스크린샷 2026-02-02 200352" src="https://github.com/user-attachments/assets/f98121bf-3fb3-4556-9a42-3049e7f341ac" />
<img width="1851" height="683" alt="스크린샷 2026-02-02 200403" src="https://github.com/user-attachments/assets/ed8beca0-82da-43a0-a43a-077d0a6984af" />
<img width="1918" height="805" alt="스크린샷 2026-02-02 200447" src="https://github.com/user-attachments/assets/ac9a7156-b388-45ab-9dc3-3de9baad7a7e" />

2. 동일한 조건으로 재검색(Store 엔티티 DB에 저장하는 로직 빠짐)
<img width="1624" height="73" alt="스크린샷 2026-02-02 200504" src="https://github.com/user-attachments/assets/81e5583c-9fab-4b98-9e5e-bf7d75965225" />


## 💬 기타(공유사항 to 리뷰어)
- 기존: 30~60초 소요
- 개선 후: 병렬 처리 적용으로 6~10초로 단축
- 하지만 아직도 느리기 때문에 추후 최적화 단계를 계속해서 이어나갈 예정입니다. (Redis 캐시 적용도 고려중)
- 코드를 실행하면 터미널에 소요 시간 로그가 출력되도록 해두었습니다. 리뷰에 참고 부탁드립니다.
