### PR TITLE
[Feat] 멤버십 바코드 조회 기능 API (매장 상세 페이지)

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/MembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/MembershipBrandController.java
@@ -5,7 +5,9 @@ import com.umc.barkit.domain.membership.service.MembershipBrandQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
+
 import io.swagger.v3.oas.annotations.Parameter;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -1,17 +1,25 @@
 package com.umc.barkit.domain.membership.controller;
 
+
 import com.umc.barkit.domain.membership.dto.request.UserMembershipBrandRequestDTO;
 import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
 import com.umc.barkit.domain.membership.service.UserMembershipBrandCommandService;
+import com.umc.barkit.domain.membership.dto.response.MembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.service.MembershipBrandQueryService;
 import com.umc.barkit.domain.membership.service.UserMembershipBrandQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+
+
 
 @RestController
 @RequiredArgsConstructor
@@ -66,6 +74,24 @@ public class UserMembershipBrandController {
     ) {
         UserMembershipBrandResponseDTO.RegisterMembershipResultDTO result =
                 userMembershipBrandCommandService.registerMembership(userId, membershipBrandId, request);
+
+        return ResponseEntity
+                .status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "멤버십 바코드 조회 기능 API",
+            description = "매장 상세 정보 페이지에서 멤버십 바코드를 조회할 수 있습니다."
+    )
+    @GetMapping("/{membershipBrandId}/barcode")
+    public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO>> getUserMembershipBarcodeDTO(
+            @PathVariable("membershipBrandId") Long membershipBrandId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        Long userId = userDetails.getUserId();
+
+        var result = userMembershipBrandQueryService.getUserMembershipBarcode(userId,membershipBrandId);
 
         return ResponseEntity
                 .status(GeneralSuccessCode.OK.getStatus())

--- a/src/main/java/com/umc/barkit/domain/membership/converter/MembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/MembershipBrandConverter.java
@@ -2,6 +2,7 @@ package com.umc.barkit.domain.membership.converter;
 
 import com.umc.barkit.domain.membership.dto.response.MembershipBrandResponseDTO;
 import com.umc.barkit.domain.membership.entity.MembershipBrand;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,6 +58,7 @@ public class MembershipBrandConverter {
                 .build();
     }
 
+
     public static MembershipBrandResponseDTO.SearchResultDTO toSearchResultDTO(
             List<MembershipBrand> brands,
             Long nextCursor,
@@ -70,4 +72,5 @@ public class MembershipBrandConverter {
                 .hasNext(hasNext)
                 .build();
     }
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -1,14 +1,19 @@
 package com.umc.barkit.domain.membership.converter;
 
+
 import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
 import com.umc.barkit.domain.membership.dto.request.UserMembershipBrandRequestDTO;
 import com.umc.barkit.domain.membership.entity.MembershipBrand;
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.membership.exception.MembershipException;
+import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
 import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
 import com.umc.barkit.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import com.umc.barkit.domain.membership.dto.response.MembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -73,4 +78,25 @@ public class UserMembershipBrandConverter {
                 .barcodeRawValue(userMembershipBrand.getBarcodeRawValue())
                 .build();
     }
+
+    //MembershipBrand Entity List -> BarcodeDTO 변환
+    public UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO toBarcodeDTO(UserMembershipBrand umb){
+
+        MembershipBrand brand = membershipBrandRepository.findById(umb.getMembershipBrandId())
+                .orElseThrow(() -> new MembershipException(MembershipErrorCode.BRAND4001));
+
+        return UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO.builder()
+                .membershipNumber(umb.getMembershipNumber())
+                .barcodeRawValue(umb.getBarcodeRawValue())
+                .logoUrl(brand.getLogoUrl())
+                .brandName(brand.getName())
+                .build();
+    }
 }
+
+
+
+
+
+
+

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -38,4 +38,13 @@ public class UserMembershipBrandResponseDTO {
         private String membershipNumber;
         private String barcodeRawValue;
     }
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class UserMembershipBarcodeDTO {
+        private String membershipNumber;
+        private String barcodeRawValue;
+        private String logoUrl;
+        private String brandName;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
+++ b/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
@@ -30,4 +30,5 @@ public class UserMembershipBrand extends BaseEntity {
 
     @Column(name = "is_main", nullable = false)
     private Boolean isMain = false;
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/exception/MembershipException.java
+++ b/src/main/java/com/umc/barkit/domain/membership/exception/MembershipException.java
@@ -1,0 +1,10 @@
+package com.umc.barkit.domain.membership.exception;
+
+import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
+
+public class MembershipException extends GeneralException {
+    public MembershipException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipErrorCode.java
@@ -1,0 +1,35 @@
+package com.umc.barkit.domain.membership.exception.code;
+
+import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MembershipErrorCode implements BaseErrorCode {
+    // ========== 멤버십 브랜드 에러 (BRAND) ==========
+    BRAND4001(HttpStatus.NOT_FOUND, "BRAND4001", "존재하지 않는 브랜드입니다."),
+    BRAND4002(HttpStatus.CONFLICT, "BRAND4002", "이미 존재하는 브랜드입니다."),
+
+    // ========== 멤버십 카드 에러 (MEMBERSHIP) ==========
+    MEMBERSHIP4001(HttpStatus.BAD_REQUEST, "MEMBERSHIP4001", "멤버십 번호를 입력해주세요."),
+    MEMBERSHIP4002(HttpStatus.BAD_REQUEST, "MEMBERSHIP4002", "멤버십 번호는 최대 20자까지 입력 가능합니다."),
+    MEMBERSHIP4003(HttpStatus.BAD_REQUEST, "MEMBERSHIP4003", "멤버십 번호는 숫자만 입력 가능합니다."),
+    MEMBERSHIP4004(HttpStatus.NOT_FOUND,"MEMBERSHIP4004","등록된 사용자 멤버십이 존재하지 않습니다."),
+    // ========== 바코드 에러 (BARCODE) ==========
+    BARCODE4001(HttpStatus.BAD_REQUEST, "BARCODE4001", "지원하지 않는 바코드 형식입니다."),
+
+    // ========== 사진 에러 (PHOTO) ==========
+    PHOTO4001(HttpStatus.BAD_REQUEST, "PHOTO4001", "사진을 업로드해주세요."),
+    PHOTO4002(HttpStatus.BAD_REQUEST, "PHOTO4002", "사진 크기는 최대 10MB까지 가능합니다."),
+    PHOTO4003(HttpStatus.BAD_REQUEST, "PHOTO4003", "jpg, png 형식만 업로드 가능합니다."),
+    PHOTO4004(HttpStatus.BAD_REQUEST, "PHOTO4004", "이미지 파일이 손상되었거나 읽을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+
+}

--- a/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipSuccessCode.java
@@ -1,0 +1,4 @@
+package com.umc.barkit.domain.membership.exception.code;
+
+public enum MembershipSuccessCode {
+}

--- a/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepository.java
@@ -13,4 +13,6 @@ public interface MembershipBrandRepository extends JpaRepository<MembershipBrand
 
     Optional<MembershipBrand> findByName(String name);
 
+    boolean existsById(Long userId);
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
@@ -4,7 +4,11 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UserMembershipBrandRepository extends JpaRepository<UserMembershipBrand, Long>, UserMembershipBrandRepositoryCustom {
+
+    Optional<UserMembershipBrand> findByUserIdAndMembershipBrandId(Long userId,Long membershipBrandId);
 
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
@@ -11,4 +11,7 @@ public interface UserMembershipBrandQueryService {
             Long cursor,
             Integer limit
     );
+
+    UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO getUserMembershipBarcode(Long userId,Long membershipBrandId);
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -1,15 +1,32 @@
 package com.umc.barkit.domain.membership.service;
 
 import com.umc.barkit.domain.membership.converter.UserMembershipBrandConverter;
+
 import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+
+import com.umc.barkit.domain.membership.dto.response.MembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.entity.MembershipBrand;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
+import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
+import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 
+import java.util.List;
+import java.util.Optional;
+
+import com.umc.barkit.domain.membership.exception.MembershipException;
+
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -17,6 +34,7 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
 
     private final UserMembershipBrandRepository userMembershipBrandRepository;
     private final UserMembershipBrandConverter userMembershipBrandConverter;
+    private final MembershipBrandRepository membershipBrandRepository;
 
     @Override
     public UserMembershipBrandResponseDTO.SearchResultDTO searchUserMembershipBrands(
@@ -48,4 +66,30 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
         // 6. DTO 변환 및 반환
         return userMembershipBrandConverter.toSearchResultDTO(resultBrands, nextCursor, hasNext);
     }
+
+
+    public UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO getUserMembershipBarcode(Long userId,Long membershipBrandId){
+
+        MembershipBrand brand = membershipBrandRepository.findById(membershipBrandId)
+                .orElseThrow(() -> new MembershipException(MembershipErrorCode.BRAND4001));
+
+
+        Optional<UserMembershipBrand> umbOpt =
+                userMembershipBrandRepository
+                        .findByUserIdAndMembershipBrandId(userId, membershipBrandId);
+
+
+        if (umbOpt.isEmpty()) {
+            return UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO.builder()
+                    .membershipNumber("")
+                    .barcodeRawValue("")
+                    .logoUrl(brand.getLogoUrl())
+                    .brandName(brand.getName())
+                    .build();
+        }
+
+        return userMembershipBrandConverter.toBarcodeDTO(umbOpt.get());
+    }
+
+
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 멤버십 바코드 조회 기능 API (매장 상세 페이지)

## 🛠️ 작업 상세 내용
- [x] 멤버십 바코드 조회 기능 API 구현 (GET /api/user-membership-brands/{membershipBrandId}/barcode)
- [x] Response DTO, Converter, Repository, QueryService 로직 구현

## 📸 스크린샷 (선택)
- user_id가 115인 토큰으로 테스트함
토큰 : 
"eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzZW9AZXhhbXBsZS5jb20iLCJyb2xlIjoiUk9MRV9VU0VSIiwiZW1haWwiOiJzZW9AZXhhbXBsZS5jb20iLCJpYXQiOjE3NzAwNDg5MDMsImV4cCI6MTc3MDA2MzMwM30.fUSUZXaSiF_US33QLx4UrE0NYMLyQ35fClzqORG-mb8FYK_AYypD8EonucVZC7o9vY6wDTton08tpvxlwimrqQ"
<img width="877" height="407" alt="스크린샷 2026-02-03 오전 1 22 28" src="https://github.com/user-attachments/assets/1b341a08-ec84-4bfa-8f2a-b6163f88a312" />


1. 멤버십 브랜드 존재 및 유저가 해당 브랜드 등록
<img width="1414" height="851" alt="스크린샷 2026-02-03 오전 1 20 44" src="https://github.com/user-attachments/assets/66418a87-4c0e-4819-95cb-d7778de46baf" />
<img width="876" height="392" alt="스크린샷 2026-02-03 오전 1 21 43" src="https://github.com/user-attachments/assets/68958dc2-6f0d-4fe2-b8d5-3e933db23caf" />


2. 멤버십 브랜드는 존재하지만 유저가 그 멤버십을 등록하지 않음
<img width="1425" height="857" alt="스크린샷 2026-02-03 오전 1 21 08" src="https://github.com/user-attachments/assets/c271af25-3252-441d-a16d-d6e0e1dab29f" />


3. 멤버십 브랜드가 존재하지 않음
<img width="1428" height="785" alt="스크린샷 2026-02-03 오전 1 21 33" src="https://github.com/user-attachments/assets/2e4955b9-1db9-42e5-9d14-c8937edf9519" />
<img width="889" height="378" alt="스크린샷 2026-02-03 오전 1 22 12" src="https://github.com/user-attachments/assets/c278045e-a050-464d-8c46-abb914fa3a41" />

## 💬 기타(공유사항 to 리뷰어)