### PR TITLE
[Feat] home dashboard 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/controller/FavoriteController.java
@@ -6,11 +6,14 @@ import com.umc.barkit.domain.favorite.entity.FavoriteStoreBrand;
 import com.umc.barkit.domain.favorite.service.FavoriteService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "Favorite", description = "즐겨찾기 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/favorites")
@@ -18,7 +21,10 @@ public class FavoriteController {
 
     private final FavoriteService favoriteService;
 
-    // 즐겨찾기 조회 (최대 5개)
+    @Operation(
+            summary = "즐겨찾기 목록 조회",
+            description = "로그인 사용자가 즐겨찾기한 매장 목록을 최대 5개까지 조회합니다."
+    )
     @GetMapping
     public ApiResponse<List<FavoriteResponse>> getFavorites(
             @RequestHeader("Authorization") String token
@@ -33,7 +39,10 @@ public class FavoriteController {
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, result);
     }
 
-    // 즐겨찾기 추가
+    @Operation(
+            summary = "즐겨찾기 추가",
+            description = "특정 매장을 즐겨찾기에 추가합니다. 최대 5개까지 등록 가능하며, 중복 등록은 제한됩니다."
+    )
     @PostMapping
     public ApiResponse<Void> createFavorite(
             @RequestHeader("Authorization") String token,
@@ -45,7 +54,10 @@ public class FavoriteController {
         return ApiResponse.onSuccess(GeneralSuccessCode.OK, null);
     }
 
-    // 즐겨찾기 삭제
+    @Operation(
+            summary = "즐겨찾기 삭제",
+            description = "즐겨찾기한 매장을 삭제합니다. 실제 DB 삭제가 아닌 Soft Delete 방식으로 처리됩니다."
+    )
     @DeleteMapping("/{favoriteId}")
     public ApiResponse<Void> deleteFavorite(
             @RequestHeader("Authorization") String token,

--- a/src/main/java/com/umc/barkit/domain/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/umc/barkit/domain/favorite/controller/FavoriteController.java
@@ -22,7 +22,7 @@ public class FavoriteController {
     private final FavoriteService favoriteService;
 
     @Operation(
-            summary = "즐겨찾기 목록 조회",
+            summary = "즐겨찾기 목록 조회 (사용 안하는 api)",
             description = "로그인 사용자가 즐겨찾기한 매장 목록을 최대 5개까지 조회합니다."
     )
     @GetMapping
@@ -40,7 +40,7 @@ public class FavoriteController {
     }
 
     @Operation(
-            summary = "즐겨찾기 추가",
+            summary = "즐겨찾기 추가 (사용 안하는 api)",
             description = "특정 매장을 즐겨찾기에 추가합니다. 최대 5개까지 등록 가능하며, 중복 등록은 제한됩니다."
     )
     @PostMapping
@@ -55,7 +55,7 @@ public class FavoriteController {
     }
 
     @Operation(
-            summary = "즐겨찾기 삭제",
+            summary = "즐겨찾기 삭제 (사용 안하는 api)",
             description = "즐겨찾기한 매장을 삭제합니다. 실제 DB 삭제가 아닌 Soft Delete 방식으로 처리됩니다."
     )
     @DeleteMapping("/{favoriteId}")

--- a/src/main/java/com/umc/barkit/domain/home/controller/HomeController.java
+++ b/src/main/java/com/umc/barkit/domain/home/controller/HomeController.java
@@ -4,6 +4,7 @@ import com.umc.barkit.domain.home.dto.response.HomeDashboardResponse;
 import com.umc.barkit.domain.home.service.HomeDashboardService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -17,6 +18,11 @@ public class HomeController {
 
     private final HomeDashboardService homeDashboardService;
 
+    @Operation(
+            summary = "홈 대시보드 조회",
+            description = "홈 화면 진입 시 필요한 핵심 정보를 한 번에 조회합니다. " +
+                    "즐겨찾기 매장 요약, 보유 멤버십 카드 정보를 포함합니다."
+    )
     @GetMapping("/dashboard")
     public ResponseEntity<ApiResponse<HomeDashboardResponse.DashboardDTO>> getHomeDashboard() {
 

--- a/src/main/java/com/umc/barkit/domain/home/controller/HomeController.java
+++ b/src/main/java/com/umc/barkit/domain/home/controller/HomeController.java
@@ -4,9 +4,11 @@ import com.umc.barkit.domain.home.dto.response.HomeDashboardResponse;
 import com.umc.barkit.domain.home.service.HomeDashboardService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,13 +23,16 @@ public class HomeController {
     @Operation(
             summary = "홈 대시보드 조회",
             description = "홈 화면 진입 시 필요한 핵심 정보를 한 번에 조회합니다. " +
-                    "사용자가 보유한 멤버십 카드 목록을 제공합니다."
+                    "로그인 사용자를 기준으로 보유 멤버십 카드 목록을 제공합니다."
     )
     @GetMapping("/dashboard")
-    public ResponseEntity<ApiResponse<HomeDashboardResponse.DashboardDTO>> getHomeDashboard() {
+    public ResponseEntity<ApiResponse<HomeDashboardResponse.DashboardDTO>> getHomeDashboard(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
 
         HomeDashboardResponse.DashboardDTO result =
-                homeDashboardService.getDashboard();
+                homeDashboardService.getDashboard(userId);
 
         return ResponseEntity
                 .status(GeneralSuccessCode.OK.getStatus())

--- a/src/main/java/com/umc/barkit/domain/home/controller/HomeController.java
+++ b/src/main/java/com/umc/barkit/domain/home/controller/HomeController.java
@@ -21,7 +21,7 @@ public class HomeController {
     @Operation(
             summary = "홈 대시보드 조회",
             description = "홈 화면 진입 시 필요한 핵심 정보를 한 번에 조회합니다. " +
-                    "즐겨찾기 매장 요약, 보유 멤버십 카드 정보를 포함합니다."
+                    "사용자가 보유한 멤버십 카드 목록을 제공합니다."
     )
     @GetMapping("/dashboard")
     public ResponseEntity<ApiResponse<HomeDashboardResponse.DashboardDTO>> getHomeDashboard() {

--- a/src/main/java/com/umc/barkit/domain/home/controller/HomeController.java
+++ b/src/main/java/com/umc/barkit/domain/home/controller/HomeController.java
@@ -1,0 +1,30 @@
+package com.umc.barkit.domain.home.controller;
+
+import com.umc.barkit.domain.home.dto.response.HomeDashboardResponse;
+import com.umc.barkit.domain.home.service.HomeDashboardService;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+public class HomeController {
+
+    private final HomeDashboardService homeDashboardService;
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<ApiResponse<HomeDashboardResponse.DashboardDTO>> getHomeDashboard() {
+
+        HomeDashboardResponse.DashboardDTO result =
+                homeDashboardService.getDashboard();
+
+        return ResponseEntity
+                .status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
+++ b/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
@@ -1,0 +1,70 @@
+package com.umc.barkit.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 홈 대시보드 전용 응답 DTO
+ * - 홈 화면 전용
+ * - 다른 API와 공유 ❌
+ */
+public class HomeDashboardResponse {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DashboardDTO {
+
+        /**
+         * 즐겨찾기 매장 요약 (최대 5개)
+         */
+        private List<FavoriteStoreDTO> favoriteStores;
+
+        /**
+         * 사용자 보유 멤버십 요약
+         * - ACTIVE만
+         * - 현재는 최근 등록순 기준
+         */
+        private List<MembershipSummaryDTO> memberships;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class FavoriteStoreDTO {
+
+        private Long favoriteId;
+        private Long storeId;
+        private String storeName;
+
+        /**
+         * 사용자 기준:
+         * 내가 가진 멤버십 중 하나라도
+         * 이 매장에서 혜택 가능하면 true
+         */
+        private Boolean isBenefitAvailable;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MembershipSummaryDTO {
+
+        private Long membershipBrandId;
+        private String name;
+        private String logoUrl;
+
+        /**
+         * TODO
+         * - 멤버십 사용 이력 테이블 없음
+         * - 1차 구현: 최근 등록순
+         */
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
+++ b/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
@@ -10,7 +10,8 @@ import java.util.List;
 /**
  * 홈 대시보드 전용 응답 DTO
  * - 홈 화면 전용
- * - 다른 API와 공유 ❌
+ * - 멤버십 카드 리스트 제공
+ * - 매장 즐겨찾기 기능 제거됨 (기획 변경)
  */
 public class HomeDashboardResponse {
 
@@ -21,14 +22,7 @@ public class HomeDashboardResponse {
     public static class DashboardDTO {
 
         /**
-         * 즐겨찾기 매장 요약 (최대 5개)
-         */
-        private List<FavoriteStoreDTO> favoriteStores;
-
-        /**
-         * 사용자 보유 멤버십 요약
-         * - ACTIVE만
-         * - 현재는 최근 등록순 기준
+         * 사용자 보유 멤버십 카드 요약
          */
         private List<MembershipSummaryDTO> memberships;
     }
@@ -37,34 +31,21 @@ public class HomeDashboardResponse {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class FavoriteStoreDTO {
-
-        private Long favoriteId;
-        private Long storeId;
-        private String storeName;
-
-        /**
-         * 사용자 기준:
-         * 내가 가진 멤버십 중 하나라도
-         * 이 매장에서 혜택 가능하면 true
-         */
-        private Boolean isBenefitAvailable;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class MembershipSummaryDTO {
 
+        /**
+         * 멤버십 브랜드 ID
+         */
         private Long membershipBrandId;
-        private String name;
-        private String logoUrl;
 
         /**
-         * TODO
-         * - 멤버십 사용 이력 테이블 없음
-         * - 1차 구현: 최근 등록순
+         * 멤버십 브랜드 이름
          */
+        private String name;
+
+        /**
+         * 멤버십 브랜드 로고 URL
+         */
+        private String logoUrl;
     }
 }

--- a/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
+++ b/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
@@ -25,6 +25,15 @@ public class HomeDashboardResponse {
          * 사용자 보유 멤버십 카드 요약
          */
         private List<MembershipSummaryDTO> memberships;
+
+        /**
+         * 사용자 보유 멤버십 목록
+         *
+         * - 현재는 사용자가 보유한 모든 멤버십을 단순 나열
+         * - 대표 멤버십(is_main)은 추후 반영 예정
+         *   → user_membership_brand.is_main 컬럼 추가 후
+         *      우선 정렬 또는 별도 필드로 분리 예정
+         */
     }
 
     @Getter

--- a/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
+++ b/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
@@ -25,15 +25,6 @@ public class HomeDashboardResponse {
          * 사용자 보유 멤버십 카드 요약
          */
         private List<MembershipSummaryDTO> memberships;
-
-        /**
-         * 사용자 보유 멤버십 목록
-         *
-         * - 현재는 사용자가 보유한 모든 멤버십을 단순 나열
-         * - 대표 멤버십(is_main)은 추후 반영 예정
-         *   → user_membership_brand.is_main 컬럼 추가 후
-         *      우선 정렬 또는 별도 필드로 분리 예정
-         */
     }
 
     @Getter
@@ -41,6 +32,12 @@ public class HomeDashboardResponse {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MembershipSummaryDTO {
+
+        /**
+         * 유저 멤버십 ID
+         * - 대표 멤버십 설정 / 상세 조회 등에 사용
+         */
+        private Long userMembershipBrandId; // 추가됨
 
         /**
          * 멤버십 브랜드 ID

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardService.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardService.java
@@ -1,0 +1,8 @@
+package com.umc.barkit.domain.home.service;
+
+import com.umc.barkit.domain.home.dto.response.HomeDashboardResponse;
+
+public interface HomeDashboardService {
+
+    HomeDashboardResponse.DashboardDTO getDashboard();
+}

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardService.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardService.java
@@ -4,5 +4,5 @@ import com.umc.barkit.domain.home.dto.response.HomeDashboardResponse;
 
 public interface HomeDashboardService {
 
-    HomeDashboardResponse.DashboardDTO getDashboard();
+    HomeDashboardResponse.DashboardDTO getDashboard(Long userId);
 }

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
@@ -8,6 +8,9 @@ import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -35,8 +38,14 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                         .stream()
                         .sorted(
                                 Comparator
-                                        .comparing(UserMembershipBrand::getIsMain).reversed()
-                                        .thenComparing(UserMembershipBrand::getCreatedAt)
+                                        .comparing(
+                                                UserMembershipBrand::getIsMain,
+                                                Comparator.nullsLast(Boolean::compareTo)
+                                        ).reversed()
+                                        .thenComparing(
+                                                UserMembershipBrand::getCreatedAt,
+                                                Comparator.nullsLast(Comparator.naturalOrder())
+                                        )
                         )
                         .toList();
 
@@ -78,7 +87,12 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
     }
 
     private Long getCurrentUserId() {
-        // TODO: SecurityContext 연동
-        return 100L;
+        Authentication authentication =
+                SecurityContextHolder.getContext().getAuthentication();
+
+        CustomUserDetails userDetails =
+                (CustomUserDetails) authentication.getPrincipal();
+
+        return userDetails.getUserId();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
@@ -1,8 +1,5 @@
 package com.umc.barkit.domain.home.service;
 
-import com.umc.barkit.domain.favorite.entity.FavoriteStoreBrand;
-import com.umc.barkit.domain.favorite.enums.FavoriteStoreStatus;
-import com.umc.barkit.domain.favorite.repository.FavoriteStoreBrandRepository;
 import com.umc.barkit.domain.home.dto.response.HomeDashboardResponse;
 import com.umc.barkit.domain.membership.entity.MembershipBrand;
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
@@ -19,7 +16,6 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class HomeDashboardServiceImpl implements HomeDashboardService {
 
-    private final FavoriteStoreBrandRepository favoriteStoreBrandRepository;
     private final UserMembershipBrandRepository userMembershipBrandRepository;
     private final MembershipBrandRepository membershipBrandRepository;
 
@@ -28,19 +24,11 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
 
         Long userId = getCurrentUserId();
 
-        // 즐겨찾기 매장 (ACTIVE, 최신 5개)
-        List<FavoriteStoreBrand> favorites =
-                favoriteStoreBrandRepository
-                        .findTop5ByUser_IdAndStatusOrderByCreatedAtDesc(
-                                userId,
-                                FavoriteStoreStatus.ACTIVE
-                        );
-
-        // 사용자 보유 멤버십 (ID만)
+        // 1️ 사용자 보유 멤버십 (ID만 조회)
         List<UserMembershipBrand> userMemberships =
                 userMembershipBrandRepository.findByUserId(userId);
 
-        // MembershipBrand 조회
+        // 2 MembershipBrand 조회
         List<MembershipBrand> membershipBrands =
                 membershipBrandRepository.findAllById(
                         userMemberships.stream()
@@ -48,19 +36,7 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                                 .toList()
                 );
 
-        //  즐겨찾기 매장 DTO
-        List<HomeDashboardResponse.FavoriteStoreDTO> favoriteStoreDTOs =
-                favorites.stream()
-                        .map(favorite -> HomeDashboardResponse.FavoriteStoreDTO.builder()
-                                .favoriteId(favorite.getId())
-                                .storeId(favorite.getStoreBrand().getId())
-                                .storeName(favorite.getStoreBrand().getName())
-                                .isBenefitAvailable(false) // TODO: 혜택 판단 QueryDSL
-                                .build()
-                        )
-                        .toList();
-
-        //  멤버십 요약 DTO
+        // 3️ 멤버십 요약 DTO 변환
         List<HomeDashboardResponse.MembershipSummaryDTO> membershipDTOs =
                 membershipBrands.stream()
                         .map(brand -> HomeDashboardResponse.MembershipSummaryDTO.builder()
@@ -72,13 +48,12 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                         .toList();
 
         return HomeDashboardResponse.DashboardDTO.builder()
-                .favoriteStores(favoriteStoreDTOs)
                 .memberships(membershipDTOs)
                 .build();
     }
 
     private Long getCurrentUserId() {
-        // TODO SecurityContext 연동
+        // TODO: SecurityContext 연동
         return 100L;
     }
 }

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
@@ -8,11 +8,10 @@ import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.umc.barkit.global.auth.details.CustomUserDetails;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 
-import java.util.*;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -24,14 +23,15 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
     private final MembershipBrandRepository membershipBrandRepository;
 
     @Override
-    public HomeDashboardResponse.DashboardDTO getDashboard() {
-
-        Long userId = getCurrentUserId();
+    public HomeDashboardResponse.DashboardDTO getDashboard(Long userId) {
 
         /**
-         * 1 사용자 보유 멤버십 조회
-         * - 대표 멤버십(isMain = true) 우선
-         * - 이후 등록순(createdAt ASC)
+         * 사용자 보유 멤버십 정렬 규칙
+         *
+         * 1. 대표 멤버십(isMain = true) 우선 노출
+         * 2. 동일 조건 내에서는 등록순(createdAt ASC)
+         *
+         * → 홈 화면에서 대표 멤버십을 가장 먼저 보여주기 위한 UX 정책
          */
         List<UserMembershipBrand> userMemberships =
                 userMembershipBrandRepository.findByUserId(userId)
@@ -50,7 +50,7 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                         .toList();
 
         /**
-         * 2. MembershipBrand 조회 (ID → Entity 매핑)
+         * MembershipBrand 조회 (ID → Entity 매핑)
          */
         Map<Long, MembershipBrand> membershipBrandMap =
                 membershipBrandRepository.findAllById(
@@ -65,7 +65,7 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                         ));
 
         /**
-         * 3. 정렬된 userMembership 순서를 유지한 채 DTO 변환
+         * DTO 변환
          */
         List<HomeDashboardResponse.MembershipSummaryDTO> membershipDTOs =
                 userMemberships.stream()
@@ -84,15 +84,5 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
         return HomeDashboardResponse.DashboardDTO.builder()
                 .memberships(membershipDTOs)
                 .build();
-    }
-
-    private Long getCurrentUserId() {
-        Authentication authentication =
-                SecurityContextHolder.getContext().getAuthentication();
-
-        CustomUserDetails userDetails =
-                (CustomUserDetails) authentication.getPrincipal();
-
-        return userDetails.getUserId();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
@@ -74,6 +74,7 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                                     membershipBrandMap.get(userMembership.getMembershipBrandId());
 
                             return HomeDashboardResponse.MembershipSummaryDTO.builder()
+                                    .userMembershipBrandId(userMembership.getId()) // 추가됨
                                     .membershipBrandId(brand.getId())
                                     .name(brand.getName())
                                     .logoUrl(brand.getLogoUrl())

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -24,27 +25,51 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
 
         Long userId = getCurrentUserId();
 
-        // 1️ 사용자 보유 멤버십 (ID만 조회)
+        /**
+         * 1 사용자 보유 멤버십 조회
+         * - 대표 멤버십(isMain = true) 우선
+         * - 이후 등록순(createdAt ASC)
+         */
         List<UserMembershipBrand> userMemberships =
-                userMembershipBrandRepository.findByUserId(userId);
-
-        // 2 MembershipBrand 조회
-        List<MembershipBrand> membershipBrands =
-                membershipBrandRepository.findAllById(
-                        userMemberships.stream()
-                                .map(UserMembershipBrand::getMembershipBrandId)
-                                .toList()
-                );
-
-        // 3️ 멤버십 요약 DTO 변환
-        List<HomeDashboardResponse.MembershipSummaryDTO> membershipDTOs =
-                membershipBrands.stream()
-                        .map(brand -> HomeDashboardResponse.MembershipSummaryDTO.builder()
-                                .membershipBrandId(brand.getId())
-                                .name(brand.getName())
-                                .logoUrl(brand.getLogoUrl())
-                                .build()
+                userMembershipBrandRepository.findByUserId(userId)
+                        .stream()
+                        .sorted(
+                                Comparator
+                                        .comparing(UserMembershipBrand::getIsMain).reversed()
+                                        .thenComparing(UserMembershipBrand::getCreatedAt)
                         )
+                        .toList();
+
+        /**
+         * 2. MembershipBrand 조회 (ID → Entity 매핑)
+         */
+        Map<Long, MembershipBrand> membershipBrandMap =
+                membershipBrandRepository.findAllById(
+                                userMemberships.stream()
+                                        .map(UserMembershipBrand::getMembershipBrandId)
+                                        .toList()
+                        )
+                        .stream()
+                        .collect(Collectors.toMap(
+                                MembershipBrand::getId,
+                                brand -> brand
+                        ));
+
+        /**
+         * 3. 정렬된 userMembership 순서를 유지한 채 DTO 변환
+         */
+        List<HomeDashboardResponse.MembershipSummaryDTO> membershipDTOs =
+                userMemberships.stream()
+                        .map(userMembership -> {
+                            MembershipBrand brand =
+                                    membershipBrandMap.get(userMembership.getMembershipBrandId());
+
+                            return HomeDashboardResponse.MembershipSummaryDTO.builder()
+                                    .membershipBrandId(brand.getId())
+                                    .name(brand.getName())
+                                    .logoUrl(brand.getLogoUrl())
+                                    .build();
+                        })
                         .toList();
 
         return HomeDashboardResponse.DashboardDTO.builder()

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
@@ -1,0 +1,84 @@
+package com.umc.barkit.domain.home.service;
+
+import com.umc.barkit.domain.favorite.entity.FavoriteStoreBrand;
+import com.umc.barkit.domain.favorite.enums.FavoriteStoreStatus;
+import com.umc.barkit.domain.favorite.repository.FavoriteStoreBrandRepository;
+import com.umc.barkit.domain.home.dto.response.HomeDashboardResponse;
+import com.umc.barkit.domain.membership.entity.MembershipBrand;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
+import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeDashboardServiceImpl implements HomeDashboardService {
+
+    private final FavoriteStoreBrandRepository favoriteStoreBrandRepository;
+    private final UserMembershipBrandRepository userMembershipBrandRepository;
+    private final MembershipBrandRepository membershipBrandRepository;
+
+    @Override
+    public HomeDashboardResponse.DashboardDTO getDashboard() {
+
+        Long userId = getCurrentUserId();
+
+        // 즐겨찾기 매장 (ACTIVE, 최신 5개)
+        List<FavoriteStoreBrand> favorites =
+                favoriteStoreBrandRepository
+                        .findTop5ByUser_IdAndStatusOrderByCreatedAtDesc(
+                                userId,
+                                FavoriteStoreStatus.ACTIVE
+                        );
+
+        // 사용자 보유 멤버십 (ID만)
+        List<UserMembershipBrand> userMemberships =
+                userMembershipBrandRepository.findByUserId(userId);
+
+        // MembershipBrand 조회
+        List<MembershipBrand> membershipBrands =
+                membershipBrandRepository.findAllById(
+                        userMemberships.stream()
+                                .map(UserMembershipBrand::getMembershipBrandId)
+                                .toList()
+                );
+
+        //  즐겨찾기 매장 DTO
+        List<HomeDashboardResponse.FavoriteStoreDTO> favoriteStoreDTOs =
+                favorites.stream()
+                        .map(favorite -> HomeDashboardResponse.FavoriteStoreDTO.builder()
+                                .favoriteId(favorite.getId())
+                                .storeId(favorite.getStoreBrand().getId())
+                                .storeName(favorite.getStoreBrand().getName())
+                                .isBenefitAvailable(false) // TODO: 혜택 판단 QueryDSL
+                                .build()
+                        )
+                        .toList();
+
+        //  멤버십 요약 DTO
+        List<HomeDashboardResponse.MembershipSummaryDTO> membershipDTOs =
+                membershipBrands.stream()
+                        .map(brand -> HomeDashboardResponse.MembershipSummaryDTO.builder()
+                                .membershipBrandId(brand.getId())
+                                .name(brand.getName())
+                                .logoUrl(brand.getLogoUrl())
+                                .build()
+                        )
+                        .toList();
+
+        return HomeDashboardResponse.DashboardDTO.builder()
+                .favoriteStores(favoriteStoreDTOs)
+                .memberships(membershipDTOs)
+                .build();
+    }
+
+    private Long getCurrentUserId() {
+        // TODO SecurityContext 연동
+        return 100L;
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
@@ -4,7 +4,16 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface UserMembershipBrandRepository extends JpaRepository<UserMembershipBrand, Long> {
+import java.util.List;
 
+@Repository
+public interface UserMembershipBrandRepository
+        extends JpaRepository<UserMembershipBrand, Long>,
+        UserMembershipBrandRepositoryCustom {
+
+    /**
+     * 사용자 보유 멤버십 목록 조회
+     * - 대표 멤버십 정렬은 서비스 레이어에서 처리
+     */
+    List<UserMembershipBrand> findByUserId(Long userId);
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
@@ -4,7 +4,9 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface UserMembershipBrandRepository extends JpaRepository<UserMembershipBrand, Long> {
-
+    List<UserMembershipBrand> findByUserId(Long userId);
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepository.java
@@ -17,4 +17,11 @@ public interface UserMembershipBrandRepository
 
     // 단건 조회 (기본 JPA 기능이지만 명시적으로 쓰는 경우)
     Optional<UserMembershipBrand> findById(Long id);
+
+
+    // 추가: 특정 브랜드의 사용자 멤버십 조회
+    Optional<UserMembershipBrand> findByUserIdAndMembershipBrandId(
+            Long userId,
+            Long membershipBrandId
+    );
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
홈 화면 진입 시 로그인 사용자를 기준으로 보유 멤버십 정보과 대표 멤버십 정보를 한 번에 조회하는 Home Dashboard API를 구현한다.
Closes #36 
## 🛠️ 작업 상세 내용
- [x] 홈 대시보드 조회 API 구현 (GET /api/home/dashboard)
- [x] 로그인 사용자 기준 데이터 필터링 (SecurityContext 연동 전 단계에서는 임시 userId 사용)
- [x] 사용자가 보유한 멤버십 카드 요약 정보 조회(멤버십 브랜드 ID, 이름, 로고 URL 반환)
- [x] 대표 멤버십 우선 정렬(user_membership_brand.is_main = true 인 멤버십을 리스트 최상단에 노출, 그 외 멤버십은 등록 순으로 정렬)

## 📸 스크린샷 (선택)
1. 대표 멤버십이 존재할 경우
<img width="1042" height="341" alt="image" src="https://github.com/user-attachments/assets/397e7dc7-ad34-4331-b4ba-e32d25475bf1" />

<img width="3186" height="1627" alt="image" src="https://github.com/user-attachments/assets/00e8137e-46a0-4731-b74d-8807907cd2ed" />
is_main = 1 인 매장 맨 위에 정렬, 그 외 멤버십은 등록 순 정렬



2. 대표 멤버십이 존재하지 않을 경우
<img width="1659" height="806" alt="image" src="https://github.com/user-attachments/assets/fbbaaf6a-12c6-42ad-8a81-52fbb649f81a" />

<img width="3133" height="1543" alt="image" src="https://github.com/user-attachments/assets/b9c17de1-a0ea-4ab1-90b7-1bfff14b40fc" />
대표 멤버십이 없으니, 등록 순 정렬



## 💬 기타(공유사항 to 리뷰어)

- 대표 멤버십은 별도 필드 분리(mainMembership) 대신 정렬 방식으로 처리
- 추후 정책 변경 시 응답 구조 확장(mainMembership + memberships)이 가능하도록 서비스 레이어에서 분리 가능하게 구현
- 홈 대시보드는 조회(Read) 전용 API로 설계되었습니다.