### PR TITLE
♻️ [Refactor] 멤버십 등록 API 수정 및 JWT 인증 적용

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -6,11 +6,12 @@ import com.umc.barkit.domain.membership.service.UserMembershipBrandCommandServic
 import com.umc.barkit.domain.membership.service.UserMembershipBrandQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -19,7 +20,7 @@ import org.springframework.web.bind.annotation.*;
 public class UserMembershipBrandController {
 
     private final UserMembershipBrandQueryService userMembershipBrandQueryService;
-    private final UserMembershipBrandCommandService userMembershipBrandCommandService;  // 변경
+    private final UserMembershipBrandCommandService userMembershipBrandCommandService;
 
     @Operation(
             summary = "사용자 보유 멤버십 브랜드 검색",
@@ -28,8 +29,7 @@ public class UserMembershipBrandController {
     )
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.SearchResultDTO>> searchUserMembershipBrands(
-            @Parameter(description = "사용자 ID", required = true, example = "100")
-            @RequestParam Long userId,  // TODO: 추후 JWT에서 추출
+            @AuthenticationPrincipal CustomUserDetails userDetails,
 
             @Parameter(description = "검색 키워드", required = true)
             @RequestParam String keyword,
@@ -40,6 +40,8 @@ public class UserMembershipBrandController {
             @Parameter(description = "한 번에 가져올 개수 (기본값: 20)", required = false, example = "20")
             @RequestParam(required = false) Integer limit
     ) {
+        Long userId = userDetails.getUserId();
+
         UserMembershipBrandResponseDTO.SearchResultDTO result =
                 userMembershipBrandQueryService.searchUserMembershipBrands(userId, keyword, cursor, limit);
 
@@ -49,21 +51,20 @@ public class UserMembershipBrandController {
     }
 
     @Operation(
-            summary = "멤버십 번호 등록",
-            description = "사용자가 멤버십 번호를 직접 입력하여 등록합니다. " +
-                    "프론트에서 멤버십 번호로 바코드 문자열을 추출하여 같이 전달합니다. " +
-                    "추후 userId가 아닌 JWT에서 추출하도록 변경 예정"
+            summary = "멤버십 등록",
+            description = "사용자가 멤버십 번호를 직접 입력하거나 바코드 이미지를 통해 등록합니다."
     )
-    @PostMapping("/{membershipBrandId}/number")
+    @PostMapping("/{membershipBrandId}")
     public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.RegisterMembershipResultDTO>> registerMembership(
-            @Parameter(description = "사용자 ID", required = true, example = "100")
-            @RequestParam Long userId,  // TODO: 추후 JWT에서 추출
+            @AuthenticationPrincipal CustomUserDetails userDetails,
 
-            @Parameter(description = "멤버십 브랜드 ID", required = true, example = "1")
+            @Parameter(description = "멤버십 브랜드 ID", required = true)
             @PathVariable Long membershipBrandId,
 
             @RequestBody UserMembershipBrandRequestDTO.RegisterMembershipDTO request
     ) {
+        Long userId = userDetails.getUserId();
+
         UserMembershipBrandResponseDTO.RegisterMembershipResultDTO result =
                 userMembershipBrandCommandService.registerMembership(userId, membershipBrandId, request);
 

--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -5,7 +5,9 @@ import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponse
 import com.umc.barkit.domain.membership.service.UserMembershipBrandCommandService;
 import com.umc.barkit.domain.membership.service.UserMembershipBrandQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
 import com.umc.barkit.global.auth.details.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -40,6 +42,11 @@ public class UserMembershipBrandController {
             @Parameter(description = "한 번에 가져올 개수 (기본값: 20)", required = false, example = "20")
             @RequestParam(required = false) Integer limit
     ) {
+        // JWT 인증 체크
+        if (userDetails == null) {
+            throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
+        }
+
         Long userId = userDetails.getUserId();
 
         UserMembershipBrandResponseDTO.SearchResultDTO result =
@@ -57,12 +64,14 @@ public class UserMembershipBrandController {
     @PostMapping("/{membershipBrandId}")
     public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.RegisterMembershipResultDTO>> registerMembership(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-
-            @Parameter(description = "멤버십 브랜드 ID", required = true)
             @PathVariable Long membershipBrandId,
-
             @RequestBody UserMembershipBrandRequestDTO.RegisterMembershipDTO request
     ) {
+        // JWT 인증 체크
+        if (userDetails == null) {
+            throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
+        }
+
         Long userId = userDetails.getUserId();
 
         UserMembershipBrandResponseDTO.RegisterMembershipResultDTO result =

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -82,7 +82,6 @@ public class UserMembershipBrandConverter {
 
         return UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO.builder()
                 .membershipNumber(umb.getMembershipNumber())
-                .barcodeRawValue(umb.getBarcodeRawValue())
                 .logoUrl(brand.getLogoUrl())
                 .brandName(brand.getName())
                 .build();

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -36,7 +36,6 @@ public class UserMembershipBrandConverter {
     }
 
     public UserMembershipBrandResponseDTO.UserBrandDTO toUserBrandDTO(UserMembershipBrand userBrand) {
-        // MembershipBrand 조회
         MembershipBrand brand = membershipBrandRepository
                 .findById(userBrand.getMembershipBrandId())
                 .orElseThrow(() -> new GeneralException(GeneralErrorCode.BRAND4001));
@@ -48,7 +47,6 @@ public class UserMembershipBrandConverter {
                 .build();
     }
 
-    // Request → Entity
     public static UserMembershipBrand toUserMembershipBrand(
             Long userId,
             Long membershipBrandId,
@@ -58,19 +56,16 @@ public class UserMembershipBrandConverter {
                 .userId(userId)
                 .membershipBrandId(membershipBrandId)
                 .membershipNumber(request.getMembershipNumber())
-                .barcodeRawValue(request.getBarcodeRawValue())
                 .isMain(false)
                 .build();
     }
 
-    // Entity → Response DTO
     public static UserMembershipBrandResponseDTO.RegisterMembershipResultDTO toRegisterMembershipResultDTO(
             UserMembershipBrand userMembershipBrand
     ) {
         return UserMembershipBrandResponseDTO.RegisterMembershipResultDTO.builder()
                 .userMembershipBrandId(userMembershipBrand.getId())
                 .membershipNumber(userMembershipBrand.getMembershipNumber())
-                .barcodeRawValue(userMembershipBrand.getBarcodeRawValue())
                 .build();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/dto/request/UserMembershipBrandRequestDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/request/UserMembershipBrandRequestDTO.java
@@ -12,7 +12,6 @@ public class UserMembershipBrandRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RegisterMembershipDTO {
-        private String membershipNumber;   // 멤버십 번호
-        private String barcodeRawValue;    // 바코드 문자열 (프론트에서 추출)
+        private String membershipNumber;
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -42,7 +42,6 @@ public class UserMembershipBrandResponseDTO {
     @AllArgsConstructor
     public static class UserMembershipBarcodeDTO {
         private String membershipNumber;
-        private String barcodeRawValue;
         private String logoUrl;
         private String brandName;
     }

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -36,6 +36,5 @@ public class UserMembershipBrandResponseDTO {
     public static class RegisterMembershipResultDTO {
         private Long userMembershipBrandId;
         private String membershipNumber;
-        private String barcodeRawValue;
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
+++ b/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
@@ -22,11 +22,8 @@ public class UserMembershipBrand extends BaseEntity {
     @Column(name = "membership_brand_id", nullable = false)
     private Long membershipBrandId;
 
-    @Column(name = "membership_number", length = 30)
+    @Column(name = "membership_number", nullable = false, length = 30)
     private String membershipNumber;
-
-    @Column(name = "barcode_raw_value", nullable = false, length = 50)
-    private String barcodeRawValue;
 
     @Column(name = "is_main", nullable = false)
     private Boolean isMain = false;

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -82,7 +82,6 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
         if (umbOpt.isEmpty()) {
             return UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO.builder()
                     .membershipNumber("")
-                    .barcodeRawValue("")
                     .logoUrl(brand.getLogoUrl())
                     .brandName(brand.getName())
                     .build();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,11 +30,6 @@ cloud:
       accessKey: ${AWS_ACCESS_KEY_ID}
       secretKey: ${AWS_SECRET_ACCESS_KEY}
 
-kakao:
-  api:
-    base-url: https://dapi.kakao.com
-    rest-key: ${KAKAO_REST_API_KEY}
-
 google:
   api:
     base-url: https://places.googleapis.com


### PR DESCRIPTION
## #️⃣ 기능 설명
> barcodeRawValue = membershipNumber이기떄문에 barcodeRawValue제거
> 멤버십 등록 API를 개선하여 번호 직접 입력과 바코드 이미지 등록을 단일 엔드포인트로 통합
> JWT 인증 방식 적용

## 🛠️ 작업 상세 내용
- [x]  barcodeRawValue 필드 제거 (Entity, DTO, Converter)
- [x] API 경로 통합: POST /{membershipBrandId}/number → POST /{membershipBrandId}
- [x] JWT 인증 적용: @AuthenticationPrincipal CustomUserDetails로 userId 추출
- [x] Request DTO 수정: membershipNumber만 받도록 단순화
- [x] Response DTO 수정: barcodeRawValue 제거, membershipNumber만 반환
- [x] 사용자 보유 브랜드 검색 API (/api/user-membership-brands/search)도 JWT 인증 방식으로 변경
- [x] UserMembershipBrandResponseDTO - UserMembershipBarcodeDTO & UserMembershipBrandConverter - toBarcodeDTO & UserMembershipBrandQueryServiceImpl - getUserMembershipBarcode에서 barcodeRawValue사용 제거

## 📸 스크린샷 (선택)
- 멤버십 등록 성공
<img width="488" height="137" alt="스크린샷 2026-02-03 오전 9 58 30" src="https://github.com/user-attachments/assets/d750b573-adc9-4f74-8377-f6a0c2564696" />

- 멤버십 등록 실패
1. 동일 멤버십 브랜드 중복 저장
<img width="430" height="123" alt="스크린샷 2026-02-03 오전 9 58 37" src="https://github.com/user-attachments/assets/31575698-ca75-481e-980c-044e6818cbd3" />


2. 멤버십 번호 타입 에러
<img width="461" height="124" alt="스크린샷 2026-02-03 오전 10 06 01" src="https://github.com/user-attachments/assets/d0674668-5a48-4455-abde-07035e1f1d3a" />


3. 멤버십 번호 12자 이하
<img width="410" height="121" alt="스크린샷 2026-02-03 오전 10 06 13" src="https://github.com/user-attachments/assets/6d72d41b-9a17-4b82-8351-bf2f81acfc81" />


4. 멤버십 번호 20자 이상
<img width="376" height="117" alt="스크린샷 2026-02-03 오전 10 06 23" src="https://github.com/user-attachments/assets/d29c1079-878c-4179-be25-bcb401fd5b04" />


5. JWT 토큰 인증 실패
<img width="338" height="120" alt="스크린샷 2026-02-03 오전 10 53 04" src="https://github.com/user-attachments/assets/b589bac6-e81c-4073-a793-59c5c9cf4c4a" />


## 💬 기타(공유사항 to 리뷰어)