### PR TITLE
[Feat] 대표 멤버십 설정/해제 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -3,6 +3,7 @@ package com.umc.barkit.domain.membership.controller;
 
 import com.umc.barkit.domain.membership.dto.request.UserMembershipBrandRequestDTO;
 import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
+import com.umc.barkit.domain.membership.exception.code.MembershipSuccessCode;
 import com.umc.barkit.domain.membership.service.UserMembershipBrandCommandService;
 import com.umc.barkit.domain.membership.dto.response.MembershipBrandResponseDTO;
 import com.umc.barkit.domain.membership.service.MembershipBrandQueryService;
@@ -96,5 +97,31 @@ public class UserMembershipBrandController {
         return ResponseEntity
                 .status(GeneralSuccessCode.OK.getStatus())
                 .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
+    }
+
+    @Operation(
+            summary = "대표 멤버십 설정/해제",
+            description = "사용자가 등록한 멤버십을 대표 멤버십으로 설정하거나 해제합니다."
+    )
+    @PatchMapping("/{userMembershipBrandId}/main")
+    public ResponseEntity<ApiResponse<Void>> updateMainMembership(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long userMembershipBrandId
+    ) {
+        Long userId = userDetails.getUserId();
+
+        //  토글 결과 받기
+        boolean isNowMain =
+                userMembershipBrandCommandService.updateMainMembership(userId, userMembershipBrandId);
+
+        //  상태에 따른 SuccessCode 분기
+        MembershipSuccessCode successCode =
+                isNowMain
+                        ? MembershipSuccessCode.MEMBERSHIP2007
+                        : MembershipSuccessCode.MEMBERSHIP2008;
+
+        return ResponseEntity
+                .status(successCode.getStatus())
+                .body(ApiResponse.onSuccess(successCode, null));
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
+++ b/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
@@ -28,7 +28,12 @@ public class UserMembershipBrand extends BaseEntity {
     @Column(name = "barcode_raw_value", nullable = false, length = 50)
     private String barcodeRawValue;
 
+    @Builder.Default
     @Column(name = "is_main", nullable = false)
     private Boolean isMain = false;
 
+    // 도메인 로직 메서드
+    public void updateIsMain(boolean isMain) {
+        this.isMain = isMain;
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipErrorCode.java
@@ -18,6 +18,8 @@ public enum MembershipErrorCode implements BaseErrorCode {
     MEMBERSHIP4002(HttpStatus.BAD_REQUEST, "MEMBERSHIP4002", "멤버십 번호는 최대 20자까지 입력 가능합니다."),
     MEMBERSHIP4003(HttpStatus.BAD_REQUEST, "MEMBERSHIP4003", "멤버십 번호는 숫자만 입력 가능합니다."),
     MEMBERSHIP4004(HttpStatus.NOT_FOUND,"MEMBERSHIP4004","등록된 사용자 멤버십이 존재하지 않습니다."),
+    MEMBERSHIP4006(HttpStatus.FORBIDDEN, "MEMBERSHIP4006", "본인의 멤버십만 대표 멤버십으로 설정할 수 있습니다."),
+    MEMBERSHIP4007(HttpStatus.BAD_REQUEST, "MEMBERSHIP4007", "대표 멤버십은 최대 3개까지 설정할 수 있습니다."),
     // ========== 바코드 에러 (BARCODE) ==========
     BARCODE4001(HttpStatus.BAD_REQUEST, "BARCODE4001", "지원하지 않는 바코드 형식입니다."),
 

--- a/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipSuccessCode.java
@@ -1,4 +1,18 @@
 package com.umc.barkit.domain.membership.exception.code;
 
-public enum MembershipSuccessCode {
+import com.umc.barkit.global.apiPayload.code.BaseSuccessCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum MembershipSuccessCode implements BaseSuccessCode {
+    // ========== 대표 멤버십 설정 성공 ==========
+    MEMBERSHIP2007(HttpStatus.OK, "MEMBERSHIP2007", "대표 멤버십으로 설정되었습니다."),
+    MEMBERSHIP2008(HttpStatus.OK, "MEMBERSHIP2008", "대표 멤버십이 해제되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
@@ -16,4 +16,7 @@ public interface UserMembershipBrandRepositoryCustom {
 
     // 멤버십 브랜드 중복 체크
     boolean existsByUserIdAndMembershipBrandId(Long userId, Long membershipBrandId);
+
+    // 대표 멤버십 개수 조회
+    int countMainByUserId(Long userId);
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
@@ -83,4 +83,19 @@ public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRep
 
         return count != null && count > 0;
     }
+
+    // 대표 멤버십 개수 조회
+    @Override
+    public int countMainByUserId(Long userId) {
+        Long count = queryFactory
+                .select(userMembershipBrand.count())
+                .from(userMembershipBrand)
+                .where(
+                        userMembershipBrand.userId.eq(userId),
+                        userMembershipBrand.isMain.isTrue()
+                )
+                .fetchOne();
+
+        return count == null ? 0 : count.intValue();
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandCommandService.java
@@ -11,4 +11,16 @@ public interface UserMembershipBrandCommandService {
             Long membershipBrandId,
             UserMembershipBrandRequestDTO.RegisterMembershipDTO request
     );
+
+    /**
+     * 대표 멤버십 설정 / 해제 기능
+     *
+     * - 특정 유저가 보유한 멤버십(UserMembershipBrand)에 대해
+     *   대표 멤버십(isMain)을 ON/OFF 토글한다.
+     * - 대표 멤버십은 최대 3개까지 설정 가능하다.
+     *
+     * @param userId 로그인한 사용자 ID
+     * @param userMembershipBrandId 대표로 설정/해제할 유저 멤버십 ID
+     */
+    boolean updateMainMembership(Long userId, Long userMembershipBrandId);
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandCommandServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandCommandServiceImpl.java
@@ -4,6 +4,7 @@ import com.umc.barkit.domain.membership.converter.UserMembershipBrandConverter;
 import com.umc.barkit.domain.membership.dto.request.UserMembershipBrandRequestDTO;
 import com.umc.barkit.domain.membership.dto.response.UserMembershipBrandResponseDTO;
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
 import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
 import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
@@ -71,5 +72,57 @@ public class UserMembershipBrandCommandServiceImpl implements UserMembershipBran
         if (membershipNumber.length() > 20) {
             throw new GeneralException(GeneralErrorCode.MEMBERSHIP4002);
         }
+    }
+
+    /**
+     * 대표 멤버십 설정 / 해제
+     *
+     * - 유저가 보유한 멤버십인지 검증
+     * - 현재 isMain 상태에 따라 ON / OFF 토글
+     * - 대표 멤버십은 최대 3개까지 허용
+     *
+     * @param userId 로그인한 사용자 ID
+     * @param userMembershipBrandId 유저 멤버십 ID
+     */
+    @Override
+    @Transactional
+    public boolean updateMainMembership(Long userId, Long userMembershipBrandId) {
+
+        // 1. 유저 멤버십 조회 + 존재 여부 검증
+        UserMembershipBrand userMembershipBrand = userMembershipBrandRepository
+                .findById(userMembershipBrandId)
+                .orElseThrow(() ->
+                        new GeneralException(MembershipErrorCode.MEMBERSHIP4004)
+                );
+        // "등록된 사용자 멤버십이 존재하지 않습니다."
+
+        // 2. 소유권 검증
+        if (!userMembershipBrand.getUserId().equals(userId)) {
+            throw new GeneralException(MembershipErrorCode.MEMBERSHIP4006);
+            // "본인의 멤버십만 대표 멤버십으로 설정할 수 있습니다."
+        }
+
+        // 3. 현재 대표 멤버십 여부
+        boolean isCurrentlyMain = Boolean.TRUE.equals(userMembershipBrand.getIsMain());
+
+        // 4. 대표 멤버십 ON 시 → 개수 제한 체크
+        if (!isCurrentlyMain) {
+            int mainCount = userMembershipBrandRepository.countMainByUserId(userId);
+
+            if (mainCount >= 3) {
+                throw new GeneralException(MembershipErrorCode.MEMBERSHIP4007);
+                // "대표 멤버십은 최대 3개까지 설정할 수 있습니다."
+            }
+        }
+
+        // 5. 토글 처리
+        boolean isNowMain = !isCurrentlyMain;
+        userMembershipBrand.updateIsMain(isNowMain);
+
+        // 6. 저장 (dirty checking으로 사실상 생략 가능)
+        userMembershipBrandRepository.save(userMembershipBrand);
+
+        // 7. 토글 결과 반환
+        return isNowMain;
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
>  사용자가 보유한 멤버십을 대표 멤버십으로 설정하거나 해제하는 API를 구현했습니다.
close #67 
## 🛠️ 작업 상세 내용
- [x] 대표 멤버십 설정/해제 API (`PATCH /api/user-membership-brands/{id}/main`) 구현
- [x] 멤버십 소유권 검증 및 예외 처리 추가 (본인 멤버십만 접근 가능)
- [x] 대표 멤버십 최대 3개 제한 로직 적용
- [x] 현재 대표 여부에 따라 ON/OFF 토글 처리
- [x] 대표 설정 / 해제에 따른 SuccessCode 분리 (`MEMBERSHIP2007`, `MEMBERSHIP2008`)  

Swagger 테스트 완료

- 대표 멤버십 설정 / 해제 토글 정상 동작
- 대표 멤버십 최대 3개 제한 검증
- 본인 소유 멤버십만 설정 가능 검증
- 존재하지 않는 멤버십 예외 처리 확인  

## 📸 스크린샷 (선택)

1. 대표 멤버십 해제 (ON → OFF)
<img width="984" height="817" alt="image" src="https://github.com/user-attachments/assets/2df69db4-5e6a-4ebd-b54a-54457dfb82c0" />
<img width="3200" height="1717" alt="image" src="https://github.com/user-attachments/assets/d39635ce-c9e7-43d7-bf71-caf1050c865a" />
대표 멤버십 설정 해제 완료

2.  대표 멤버십 설정  (OFF → ON)
<img width="671" height="809" alt="image" src="https://github.com/user-attachments/assets/c1bb835c-4a36-408a-be09-07e4a6c3b4af" />
<img width="1977" height="1758" alt="image" src="https://github.com/user-attachments/assets/6e8661d2-b7d2-43a4-9588-12e428fdb78d" />
<img width="735" height="891" alt="image" src="https://github.com/user-attachments/assets/0122502b-4b4d-46dc-ad4b-ea4db903c113" />
  
대표 멤버십 설정 완료  


3. 대표 멤버십 최대 설정 제한(3개)
<img width="698" height="788" alt="image" src="https://github.com/user-attachments/assets/cf581412-9751-467a-9630-133cc92d95da" />
<img width="1602" height="1794" alt="image" src="https://github.com/user-attachments/assets/dd6b6263-71e1-4950-a440-22cd73509de7" />
  
제한 설정 완료  
4. 존재하지 않는 멤버십 ID  
<img width="816" height="805" alt="image" src="https://github.com/user-attachments/assets/d4c3b2ed-e194-48ac-ae7b-150995d35120" />
<img width="1625" height="1787" alt="image" src="https://github.com/user-attachments/assets/2ebb1b52-e157-488e-820a-7b2572d1968b" />
  
5. 본인 소유 아닌 멤버십 접근  
user_id = 100 소유의 멤버십 id
<img width="668" height="608" alt="image" src="https://github.com/user-attachments/assets/e0aa32c6-d98c-4638-a1bc-76d7b09f39f4" />
<img width="1699" height="1671" alt="image" src="https://github.com/user-attachments/assets/579acbec-4982-4f61-b8e2-a9572afac6f3" />
 

## 💬 기타(공유사항 to 리뷰어)

- 대표 멤버십은 토글 방식으로 동작합니다.
  - 대표 → 해제
  - 비대표 → 대표 설정
- 대표 멤버십은 사용자당 최대 3개까지 허용됩니다.
- 현재 작업은 `barcodeRawValue` 필드 제거 PR 머지 이전 버전 기준으로 작성되었으며, 해당 PR 머지 시 충돌 발생 가능성은 낮고 엔티티 필드 정리 정도만 반영하면 됩니다.