### PR TITLE
매장 세부 정보 조회 API - Response Body에 보유 멤버십 리스트 추가

### DIFF
--- a/src/main/java/com/umc/barkit/domain/store/controller/StoreController.java
+++ b/src/main/java/com/umc/barkit/domain/store/controller/StoreController.java
@@ -10,6 +10,7 @@ import com.umc.barkit.domain.store.exception.code.StoreErrorCode;
 import com.umc.barkit.domain.store.exception.code.StoreSuccessCode;
 import com.umc.barkit.domain.store.service.query.StoreQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,11 +48,17 @@ public class StoreController implements StoreControllerDocs{
     }
 
     @Override
-    public ApiResponse<StoreResDTO.StoreDetail> detail(String googleId, Double userLat, Double userLng) {
+    public ApiResponse<StoreResDTO.StoreDetail> detail(
+            CustomUserDetails userDetails,
+            String googleId,
+            Double userLat,
+            Double userLng
+    ) {
+        Long userId = userDetails.getUserId();
         StoreSuccessCode code = StoreSuccessCode.FOUND;
         return ApiResponse.onSuccess(
                 code,
-                storeQueryService.detail(googleId, userLat, userLng)
+                storeQueryService.detail(googleId, userLat, userLng, userId)
         );
     }
 }

--- a/src/main/java/com/umc/barkit/domain/store/controller/StoreControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/store/controller/StoreControllerDocs.java
@@ -8,9 +8,11 @@ import com.umc.barkit.domain.store.enums.Sort;
 import com.umc.barkit.global.annotation.ValidCursor;
 import com.umc.barkit.global.annotation.ValidSize;
 import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -56,6 +58,7 @@ public interface StoreControllerDocs {
 
     @GetMapping("/store")
     ApiResponse<StoreResDTO.StoreDetail> detail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam String googleId,
             @RequestParam("userLat") Double userLat,
             @RequestParam("userLng") Double userLng

--- a/src/main/java/com/umc/barkit/domain/store/dto/res/StoreResDTO.java
+++ b/src/main/java/com/umc/barkit/domain/store/dto/res/StoreResDTO.java
@@ -52,6 +52,7 @@ public class StoreResDTO {
         private StoreContact contact;
         private StoreHourInfo hourInfo;
         private List<MembershipInfo> membership;
+        private List<UserMembershipInfo> userMembership;
         private List<StorePhotoInfo> photos;
     }
 
@@ -85,6 +86,12 @@ public class StoreResDTO {
             String url,
             Integer width,
             Integer height
+    ){}
+
+    @Builder
+    public record UserMembershipInfo(
+            String name,
+            String logoUrl
     ){}
 
 }

--- a/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryService.java
@@ -7,7 +7,7 @@ import com.umc.barkit.domain.store.enums.DistanceType;
 import com.umc.barkit.domain.store.enums.Sort;
 
 public interface StoreQueryService {
-    StoreResDTO.StoreDetail detail (String placeId, Double userLat, Double userLng);
+    StoreResDTO.StoreDetail detail (String placeId, Double userLat, Double userLng,Long userId);
 
     StoreResDTO.SearchedStoreSlice search(
             StoreReqDTO.SearchReq req,

--- a/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
@@ -1,8 +1,12 @@
 package com.umc.barkit.domain.store.service.query;
 
 import com.umc.barkit.domain.membership.entity.MembershipBrand;
+import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.membership.exception.MembershipException;
+import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandAliasRepository;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
+import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
 import com.umc.barkit.domain.store.dto.google.GooglePlaceDTO;
 import com.umc.barkit.domain.store.dto.req.StoreReqDTO;
 import com.umc.barkit.domain.store.dto.res.StoreResDTO;
@@ -50,6 +54,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
     private final StoreBrandRepository storeBrandRepository;
     private final StoreBrandAliasRepository storeBrandAliasRepository;
     private final MembershipBrandAliasRepository membershipBrandAliasRepository;
+    private final UserMembershipBrandRepository userMembershipBrandRepository;
 
     private final GoogleMapSearchClient googleClient;
     private final StoreCommandService storeCommandService;
@@ -132,7 +137,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
 
     @Transactional
     @Override
-    public StoreResDTO.StoreDetail detail(String googleId, Double userLat, Double userLng) {
+    public StoreResDTO.StoreDetail detail(String googleId, Double userLat, Double userLng,Long userId) {
 
         // DB 조회
         Store store = storeRepository.findByGoogleId(googleId)
@@ -187,7 +192,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
                 .build();
 
 
-        // 멤버십 조회
+        // 전체 멤버십 조회
         List<StoreBrandMembershipBrand> membershipEntities =
                 storeBrandMembershipBrandRepository.findByStoreBrandId(store.getBrand().getId());
 
@@ -198,6 +203,36 @@ public class StoreQueryServiceImpl implements StoreQueryService{
                         .build())
                 .toList();
 
+        //보유 멤버십 조회
+        List<Long> storeMembershipBrandIds = membershipEntities.stream()
+                .map(m -> m.getMembershipBrand().getId())
+                .toList();
+
+        List<UserMembershipBrand> userMembershipEntities = userMembershipBrandRepository.findByUserId(userId);
+
+
+        List<Long> userMembershipBrandIds = userMembershipEntities.stream()
+                .map(UserMembershipBrand::getMembershipBrandId)
+                .toList();
+
+
+        List<Long> intersectionIds = storeMembershipBrandIds.stream()
+                .filter(userMembershipBrandIds::contains)
+                .toList();
+
+        List<StoreResDTO.UserMembershipInfo> userMembershipInfos = intersectionIds.stream()
+                .map(id -> {
+                    MembershipBrand brand = membershipBrandRepository.findById(id)
+                            .orElseThrow(() -> new MembershipException(MembershipErrorCode.BRAND4001));
+                    return StoreResDTO.UserMembershipInfo.builder()
+                            .name(brand.getName())
+                            .logoUrl(brand.getLogoUrl())
+                            .build();
+                })
+                .toList();
+
+
+
         // DTO 조립
         return StoreResDTO.StoreDetail.builder()
                 .name(g.displayName() != null ? g.displayName().text() : "이름 정보 없음")
@@ -206,6 +241,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
                 .contact(contact)
                 .hourInfo(hourInfo)
                 .membership(membershipInfos)
+                .userMembership(userMembershipInfos)
                 .photos(photos)
                 .build();
     }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 기존 매장 상세 정보 조회 API는 전체 멤버십만 응답하고 있음
> 여기에 사용자가 보유한 멤버십 목록을 함께 반환하도록 기능 확장


## 🛠️ 작업 상세 내용
- [x] StoreQueryServiceImpl 보유 멤버십 조회 로직 구현

## 📸 스크린샷 (선택)
1. 유저가 멤버십을 등록한 경우
+ 유저가 등록한 멤버십
<img width="857" height="142" alt="스크린샷 2026-02-04 오후 2 01 44" src="https://github.com/user-attachments/assets/3ba06a8b-9435-4463-bff5-9a1afb3a1c3a" />

+ store_brand_id
<img width="340" height="52" alt="스크린샷 2026-02-04 오후 1 44 55" src="https://github.com/user-attachments/assets/0073a57b-2797-48f5-b3f6-612833ed1629" />

+ store_brand_membership_brand 매핑 테이블
<img width="400" height="80" alt="스크린샷 2026-02-04 오후 1 46 36" src="https://github.com/user-attachments/assets/546dc859-fd41-4ac4-9823-2fa66dfd02c8" />


<img width="1045" height="464" alt="스크린샷 2026-02-04 오후 2 03 12" src="https://github.com/user-attachments/assets/bc846c08-44c1-43e6-804f-6d32173be0a4" />

<img width="1024" height="505" alt="스크린샷 2026-02-04 오후 2 03 03" src="https://github.com/user-attachments/assets/1f6f7289-d8a0-4e50-8095-86d1a1ec971b" />


3. 유자가 멤버십을 등록하지 않은 경우
<img width="1019" height="496" alt="스크린샷 2026-02-04 오후 2 07 33" src="https://github.com/user-attachments/assets/afe0396a-c236-4218-af6b-3efdd6ad5f76" />

## 💬 기타(공유사항 to 리뷰어)