### PR TITLE
♻️ [Refactor] 리프레쉬 토큰 개발 및 로그인 시 리프레쉬 토큰 발급

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
@@ -50,11 +50,13 @@ public class UserConverter {
     // User -> LoginResponseDto
     public static UserResponseDto.LoginResponseDto toLoginDTO(
             User user,
-            String accessToken
+            String accessToken,
+            String refreshToken
     ){
         return UserResponseDto.LoginResponseDto.builder()
                 .userId(user.getId())
                 .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
@@ -21,7 +21,8 @@ public class UserResponseDto {
     @Builder
     public record LoginResponseDto(
             Long userId,
-            String accessToken
+            String accessToken,
+            String refreshToken
     ){}
 
     // 개인정보

--- a/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
@@ -15,7 +15,7 @@ import com.umc.barkit.domain.user.repository.UserTermRepository;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,7 +26,7 @@ public class UserCommandService {
     private final TermRepository termRepository;
     private final UserRepository userRepository;
     private final UserTermRepository userTermRepository;
-    private final BCryptPasswordEncoder passwordEncoder;
+    private final PasswordEncoder passwordEncoder;
 
     // 회원가입
     @Transactional

--- a/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
@@ -5,12 +5,15 @@ import com.umc.barkit.domain.user.dto.req.UserRequestDto;
 import com.umc.barkit.domain.user.dto.res.UserResponseDto;
 import com.umc.barkit.domain.user.dto.res.UserResponseDto.EmailCheckResponseDto;
 import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.entity.UserSession;
 import com.umc.barkit.domain.user.exception.UserException;
 import com.umc.barkit.domain.user.exception.code.UserErrorCode;
 import com.umc.barkit.domain.user.repository.UserRepository;
+import com.umc.barkit.domain.user.repository.UserSessionRepository;
 import com.umc.barkit.global.auth.details.CustomUserDetails;
 import com.umc.barkit.global.auth.jwt.JwtUtil;
 import jakarta.validation.Valid;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,8 +23,9 @@ import org.springframework.stereotype.Service;
 public class UserQueryService {
 
     private final UserRepository userRepository;
+    private final UserSessionRepository userSessionRepository;
     private final JwtUtil jwtUtil;
-    private final PasswordEncoder encoder;
+    private final PasswordEncoder passwordEncoder;
 
     // 아이디 중복 확인
     public UserResponseDto.EmailCheckResponseDto checkEmailAvailability(String email) {
@@ -40,7 +44,7 @@ public class UserQueryService {
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
         // 비밀번호 검증
-        if (!encoder.matches(dto.password(), user.getPasswordHash())){
+        if (!passwordEncoder.matches(dto.password(), user.getPasswordHash())){
             throw new UserException(UserErrorCode.INVALID);
         }
 
@@ -49,9 +53,32 @@ public class UserQueryService {
 
         // 엑세스 토큰 발급
         String accessToken = jwtUtil.createAccessToken(userDetails);
+        // 리프레쉬 토큰 발급
+        String refreshToken = jwtUtil.createRefreshToken(userDetails);
+
+        // 리프레쉬 토큰을 해시화하여 DB에 저장
+        saveRefreshToken(user, refreshToken);
 
         // DTO 조립
-        return UserConverter.toLoginDTO(user, accessToken);
+        return UserConverter.toLoginDTO(user, accessToken, refreshToken);
+    }
+
+    // 리프레쉬 토큰을 해시화하여 DB에 저장
+    private void saveRefreshToken(User user, String refreshToken) {
+        String refreshTokenHash = jwtUtil.hashToken(refreshToken); // 리프레쉬 토큰 해시화
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime expiresAt = now.plusSeconds(jwtUtil.getRefreshExpiration().toSeconds());  // refreshExpiration(설정값) 이후 만료
+
+        // UserSession 객체 생성
+        UserSession userSession = UserSession.builder()
+                .user(user)
+                .refreshTokenHash(refreshTokenHash)  // 해시화된 리프레쉬 토큰
+                .rememberMe(false)  // rememberMe 기본값은 false
+                .issuedAt(now)  // 발급 시각
+                .expiresAt(expiresAt)  // 만료 시각
+                .build();
+
+        userSessionRepository.save(userSession); // DB에 저장
     }
 
     // 개인정보 조회

--- a/src/main/java/com/umc/barkit/global/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/umc/barkit/global/auth/jwt/JwtUtil.java
@@ -7,11 +7,14 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
 import java.util.stream.Collectors;
 import javax.crypto.SecretKey;
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Component;
@@ -21,17 +24,27 @@ public class JwtUtil {
     private final SecretKey secretKey;
     private final Duration accessExpiration;
 
+    @Getter
+    private final Duration refreshExpiration;
+
     public JwtUtil(
             @Value("${jwt.token.secretKey}") String secret,
-            @Value("${jwt.token.expiration.access}") Long accessExpiration
+            @Value("${jwt.token.expiration.access}") Long accessExpiration,
+            @Value("${jwt.token.expiration.refresh}") Long refreshExpiration
     ) {
         this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessExpiration = Duration.ofMillis(accessExpiration);
+        this.refreshExpiration = Duration.ofMillis(refreshExpiration);
     }
 
     // AccessToken 생성
     public String createAccessToken(CustomUserDetails user) {
         return createToken(user, accessExpiration);
+    }
+
+    // RefreshToken 생성
+    public String createRefreshToken(CustomUserDetails user) {
+        return createToken(user, refreshExpiration);
     }
 
     /** 토큰에서 이메일 가져오기
@@ -88,5 +101,25 @@ public class JwtUtil {
                 .build()
                 .parseSignedClaims(token);
     }
+
+    // 리프레쉬 토큰 해시화
+    public String hashToken(String token) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] digest = md.digest(token.getBytes(StandardCharsets.UTF_8));
+            return bytesToHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not supported", e);
+        }
+    }
+
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder(bytes.length * 2);
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+
 }
 

--- a/src/main/java/com/umc/barkit/global/config/PasswordConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.umc.barkit.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -53,11 +54,6 @@ public class SecurityConfig{
     @Bean
     public JwtAuthFilter jwtAuthFilter() {
         return new JwtAuthFilter(jwtUtil, customUserDetailsService);
-    }
-
-    @Bean
-    public BCryptPasswordEncoder passwordEncoder(){
-        return new BCryptPasswordEncoder();
     }
 
     @Bean

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,4 +44,5 @@ jwt:
   token:
     secretKey: ${JWT_SECRET_KEY}
     expiration:
-      access: 14400000
+      access: 3600000
+      refresh: 2592000000


### PR DESCRIPTION
## #️⃣ 기능 설명
* 로그인 시 Access Token + Refresh Token을 함께 발급
* Refresh Token은 해시화하여 user_sessions 테이블에 저장

## 🛠️ 작업 상세 내용
- [x] 로그인 시 Refresh Token 신규 발급 로직 추가
- [x] Refresh Token을 SHA-256으로 해시화하여 user_sessions 테이블에 저장
- [x] Refresh Token 만료 시간(expires_at)을 application.yaml 설정값 기반으로 관리
- [x] 로그인 응답에 accessToken, refreshToken 모두 포함하도록 DTO 수정

## 📸 스크린샷 (선택)
* 로그인 성공
<img width="913" height="713" alt="image" src="https://github.com/user-attachments/assets/517bc357-630b-4e54-a522-484c763f368e" />

* 리프레쉬 토큰 발급 성공
<img width="876" height="252" alt="image" src="https://github.com/user-attachments/assets/7e3c90fc-e18b-4819-984f-7c1b91742d50" />

* user_sessions 테이블에 토큰 저장
<img width="1310" height="68" alt="image" src="https://github.com/user-attachments/assets/6a11eb17-62f6-48a9-952d-5a782bee5852" />

## 💬 기타(공유사항 to 리뷰어)
application.yaml에 refresh token 만료 설정값을 추가했고 GitHub Secrets 환경변수에도 반영했습니다.