### PR TITLE
✨ [feat] 지도 검색 API 검색어 정규화 및 브랜드/멤버십 별칭 검색 로직 도입

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandAliasRepository.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandAliasRepository.java
@@ -4,7 +4,6 @@ import com.umc.barkit.domain.membership.entity.MembershipBrand;
 import com.umc.barkit.domain.membership.entity.MembershipBrandAlias;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,21 +12,20 @@ import java.util.Optional;
 @Repository
 public interface MembershipBrandAliasRepository extends JpaRepository<MembershipBrandAlias, Long> {
 
-    @Query("""
-        select a.membershipBrand
-        from MembershipBrandAlias a
-        where a.normalizedAlias = :nq
-    """)
-    Optional<MembershipBrand> findMembershipByNormalizedAlias(@Param("nq") String normalizedAlias);
+    @Query(
+            "select a.membershipBrand " +
+                    "from MembershipBrandAlias a " +
+                    "where a.normalizedAlias = :nq"
+        )
+    Optional<MembershipBrand> findMembershipByNormalizedAlias(String nq);
 
-    // (선택) contains도 지원하고 싶으면
-    @Query("""
-        select a.membershipBrand
-        from MembershipBrandAlias a
-        where :nq like concat('%', a.normalizedAlias, '%')
-        order by length(a.normalizedAlias) desc
-    """)
-    List<MembershipBrand> findMembershipsContainedInQuery(@Param("nq") String normalizedQuery);
+    @Query(
+            "select a.membershipBrand " +
+                    "from MembershipBrandAlias a " +
+                    "where :nq like concat('%', a.normalizedAlias, '%') " +
+                    "order by length(a.normalizedAlias) desc"
+      )
+    List<MembershipBrand> findMembershipsContainedInQuery(String nq);
 
     boolean existsByMembershipBrandIdAndNormalizedAlias(Long membershipBrandId, String normalizedAlias);
 }

--- a/src/main/java/com/umc/barkit/domain/store/controller/StoreControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/store/controller/StoreControllerDocs.java
@@ -25,7 +25,7 @@ public interface StoreControllerDocs {
 
     // 지도 검색 기능(멤버십/매장)
     @Operation(
-            summary = "지도 검색 기능 API By remy, seoyeon (개발 중)",
+            summary = "지도 검색 기능 API By remy (개발 중)",
             description = "지도에서 멤버십/매장 기준으로 검색합니다. " +
                     "카테고리와 정렬기준(현재 내 위치/지도 중심 위치, 거리순/인기순)을 선택할 수 있습니다."
     )

--- a/src/main/java/com/umc/barkit/domain/store/dto/req/StoreReqDTO.java
+++ b/src/main/java/com/umc/barkit/domain/store/dto/req/StoreReqDTO.java
@@ -10,8 +10,8 @@ public class StoreReqDTO {
             @NotBlank(message = "query는 필수입니다.")
             @Size(max = 20, message = "query는 최대 20자까지 가능합니다.")
             @Pattern(
-                    regexp = "^[가-힣a-zA-Z0-9 ]+$",
-                    message = "query는 한글/영문/숫자(공백)만 입력 가능합니다."
+                    regexp = "^[가-힣a-zA-Z0-9 .+]+$",
+                    message = "query는 한글/영문/숫자/공백/+/./만 입력 가능합니다."
             )
             String query,
 

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandAliasRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandAliasRepository.java
@@ -4,7 +4,6 @@ import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.domain.store.entity.StoreBrandAlias;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -13,22 +12,23 @@ import java.util.Optional;
 @Repository
 public interface StoreBrandAliasRepository extends JpaRepository<StoreBrandAlias, Long> {
 
-    // 1) exact match: "olive young" -> "oliveyoung" == normalized_alias
-    @Query("""
-        select a.storeBrand
-        from StoreBrandAlias a
-        where a.normalizedAlias = :nq
-    """)
-    Optional<StoreBrand> findBrandByNormalizedAlias(@Param("nq") String normalizedAlias);
 
-    // 2) contains match: "올리브영성수점" 안에 "올리브영"이 포함되면 매칭
-    @Query("""
-        select a.storeBrand
-        from StoreBrandAlias a
-        where :nq like concat('%', a.normalizedAlias, '%')
-        order by length(a.normalizedAlias) desc
-    """)
-    List<StoreBrand> findBrandsContainedInQuery(@Param("nq") String normalizedQuery);
+    @Query(
+            "select a.storeBrand " +
+                    "from StoreBrandAlias a " +
+                    "where a.normalizedAlias = :nq"
+        )
+    Optional<StoreBrand> findBrandByNormalizedAlias(String nq);
+
+
+    @Query(
+            "select a.storeBrand " +
+                    "from StoreBrandAlias a " +
+                    "where :nq like concat('%', a.normalizedAlias, '%') " +
+                    "order by length(a.normalizedAlias) desc"
+        )
+    List<StoreBrand> findBrandsContainedInQuery(String nq);
 
     boolean existsByStoreBrandIdAndNormalizedAlias(Long storeBrandId, String normalizedAlias);
+
 }

--- a/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
@@ -312,13 +312,13 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         Double sendLat = (distanceType == DistanceType.CURRENT) ? userLat : centerLat;
         Double sendLng = (distanceType == DistanceType.CURRENT) ? userLng : centerLng;
 
+        // 검색 반경 5km 필터 적용
         List<GoogleResDTO.Place> places = googleClient.searchText(query, sendLat, sendLng);
         if (places == null || places.isEmpty()) return List.of();
 
         List<StoreResDTO.SearchedStoreMembership> membershipsDTO =
                 findMembershipsForStoreBrand(matchedBrand.getId());
 
-        // 검색 반경 5km 필터 적용
         return storeCommandService.saveAndMap(
                 matchedBrand,
                 places,
@@ -340,13 +340,13 @@ public class StoreQueryServiceImpl implements StoreQueryService{
             Double userLng
     ) {
         // 위치 없이 호출
+        // 검색 반경 5km 필터 미적용
         List<GoogleResDTO.Place> places = googleClient.searchText(query);
         if (places == null || places.isEmpty()) return List.of();
 
         List<StoreResDTO.SearchedStoreMembership> membershipsDTO =
                 findMembershipsForStoreBrand(matchedBrand.getId());
 
-        // 검색 반경 5km 필터 미적용
         return storeCommandService.saveAndMap(
                 matchedBrand,
                 places,

--- a/src/main/java/com/umc/barkit/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/umc/barkit/global/apiPayload/code/GeneralErrorCode.java
@@ -15,6 +15,9 @@ public enum GeneralErrorCode implements BaseErrorCode {
     NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON4004", "요청한 리소스를 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON5000", "서버 에러, 관리자에게 문의 바랍니다."),
 
+    // ===== Valid =====
+    VALID_FAIL(HttpStatus.BAD_REQUEST, "VALID4001", "검증에 실패했습니다."),
+
     // ===== Kakao API =====
     KAKAO_NO_RESULT(HttpStatus.NOT_FOUND, "KAKAO4001", "카카오 API 검색 결과가 없습니다."),
     KAKAO_API_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO5001", "카카오 API 호출 중 오류가 발생했습니다."),

--- a/src/main/java/com/umc/barkit/global/apiPayload/handler/GeneralExceptionAdvice.java
+++ b/src/main/java/com/umc/barkit/global/apiPayload/handler/GeneralExceptionAdvice.java
@@ -4,9 +4,17 @@ import com.umc.barkit.global.apiPayload.ApiResponse;
 import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
 import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
 import com.umc.barkit.global.apiPayload.exception.GeneralException;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * 전역 Exception Handler


### PR DESCRIPTION
## #️⃣ 기능 설명
지도 검색 API에 검색어 정규화 및 브랜드/멤버십 별칭 검색 로직을 도입합니다.

## 🛠️ 작업 상세 내용
- [x] MembershipBrandAlias, StoreBrandAlias 엔티티 클래스 생성
- [x] MembershipBrandAliasRepository, StoreBrandAliasRepository 인터페이스 생성
- [x] StoreUtil 클래스에 검색어 정규화 매서드(공백 제거, 영어 대문자 -> 소문자) 추가
- [x] 특수문자 입력 방지 수정 -> +와 ,만 허용(L.POINT, LGU+ 고려)

## 📸 스크린샷 (선택)
1. 멤버십 검색
<img width="1840" height="531" alt="스크린샷 2026-02-04 193954" src="https://github.com/user-attachments/assets/84e298e9-5447-488a-a306-c39389966542" />
<img width="1811" height="679" alt="스크린샷 2026-02-04 194003" src="https://github.com/user-attachments/assets/4e6c557b-aedc-4a6b-9edc-83bc264688c1" />
<img width="1841" height="534" alt="스크린샷 2026-02-04 194125" src="https://github.com/user-attachments/assets/76720149-62a4-49af-9a0e-b8ec1d7af311" />
<img width="1841" height="678" alt="스크린샷 2026-02-04 194132" src="https://github.com/user-attachments/assets/d6a040c5-20a2-4336-8e94-6ce0e9efa1b9" />

2. 매장 검색
<img width="1849" height="520" alt="스크린샷 2026-02-04 194222" src="https://github.com/user-attachments/assets/9ce4149f-57db-4259-bd8f-7dd13fd3215a" />
<img width="1831" height="671" alt="스크린샷 2026-02-04 194230" src="https://github.com/user-attachments/assets/f47ef848-aa60-44eb-999d-ca5e8ee77cd0" />
<img width="1852" height="528" alt="스크린샷 2026-02-04 194252" src="https://github.com/user-attachments/assets/bc3238b4-6d6b-4fc8-80aa-0c8e1eb4b711" />
<img width="1826" height="680" alt="스크린샷 2026-02-04 194259" src="https://github.com/user-attachments/assets/e1dd37b8-dc9f-401e-9faa-1f7a1222ad4f" />

## 💬 기타(공유사항 to 리뷰어)
현재 별칭 테이블에 별칭 추가 작업 진행중입니다.
멤버십의 경우 현재 검색 가능한 cj, kt, l.point, 해피포인트 별칭 추가 완료 하였습니다.
매장 브랜드의 경우 현재 20개의 브랜드 별칭 추가하였습니다. 
리뷰 하시면서 스웨거 테스트 진행 시 아래의 브랜드 별칭 검색 가능합니다.
- 파리바게뜨
- 배스킨라빈스
- 던킨
- 파스쿠찌
- 파리크라상
- 쉐이크쉑
- 잠바주스
- 빚은
- 리나스
- 라그릴리아
- 커피앳웍스
- 시티델리
- 스트릿
- 라뜰리에
- 패션5
- 퀸즈파크
- 그릭슈바인
- 파리바게뜨케이터링
- 더월드바인
- 사누끼보레