### PR TITLE
✨ [feat] Access Token 재발급 및 로그아웃 처리

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -58,6 +58,17 @@ public class UserController implements UserControllerDocs{
         return ApiResponse.onSuccess(UserSuccessCode.PERSONAL_INFO_OK, response);
     }
 
+    // 액세스 토큰 재발급 API
+    @PostMapping("/auth/refresh")
+    public ApiResponse<UserResponseDto.RefreshResponseDto> refresh(
+            @RequestBody @Valid UserRequestDto.RefreshRequestDto request
+    ) {
+        String newAccessToken = userQueryService.refreshAccessToken(request.refreshToken());
+        return ApiResponse.onSuccess(
+                UserSuccessCode.TOKEN_REFRESH_OK,
+                new UserResponseDto.RefreshResponseDto(newAccessToken)
+        );
+    }
 
     // 생년월일 변경 API
     @PatchMapping("/users/me/birth-date")
@@ -71,6 +82,7 @@ public class UserController implements UserControllerDocs{
         return ApiResponse.onSuccess(UserSuccessCode.BIRTH_DATE_UPDATED, response);
     }
 
+    // 비밀번호 변경 API
     @PatchMapping("/users/me/password")
     public ApiResponse<Void> updatePassword(
             @AuthenticationPrincipal CustomUserDetails userDetails,

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -92,5 +92,12 @@ public class UserController implements UserControllerDocs{
         return ApiResponse.onSuccess(UserSuccessCode.PASSWORD_UPDATED, null);
     }
 
+    // 로그아웃 API
+    @PostMapping("/auth/logout")
+    public ApiResponse<Void> logout(@RequestBody @Valid UserRequestDto.RefreshRequestDto request) {
+        userQueryService.logout(request.refreshToken());
+        return ApiResponse.onSuccess(UserSuccessCode.LOGOUT_OK, null);
+    }
+
 
 }

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -99,4 +99,18 @@ public interface UserControllerDocs {
     ApiResponse<UserResponseDto.RefreshResponseDto> refresh(
             @RequestBody @Valid UserRequestDto.RefreshRequestDto request
     );
+
+    @Operation(
+            summary = "로그아웃 API",
+            description = "로그아웃을 수행합니다.<br>" +
+                    "서버는 Refresh Token을 무효화하여(세션 revoke 처리) 이후 Access Token 재발급을 차단합니다.<br>" +
+                    "로그아웃 이후 동일한 Refresh Token으로는 Access Token 재발급이 불가능합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "리프레시 토큰 누락/유효하지 않음/만료/이미 무효화됨")
+    })
+    ApiResponse<Void> logout(
+            @RequestBody @Valid UserRequestDto.RefreshRequestDto request
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -87,4 +87,16 @@ public interface UserControllerDocs {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody UserRequestDto.UpdatePasswordRequestDto request
     );
+
+    @Operation(
+            summary = "액세스 토큰 재발급 API",
+            description = "Access Token 만료 시, Refresh Token을 이용해 새로운 Access Token을 발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "재발급 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "리프레시 토큰 누락/유효하지 않음/만료")
+    })
+    ApiResponse<UserResponseDto.RefreshResponseDto> refresh(
+            @RequestBody @Valid UserRequestDto.RefreshRequestDto request
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -70,4 +70,10 @@ public class UserRequestDto {
             @NotNull
             String confirmPassword
     ) {}
+
+    // 엑세스 토큰 재발급
+    public record RefreshRequestDto(
+            @NotBlank
+            String refreshToken
+    ) {}
 }

--- a/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
@@ -25,12 +25,17 @@ public class UserResponseDto {
             String refreshToken
     ){}
 
+
+    // 엑세스 토큰 응답
+    public record RefreshResponseDto(
+            String accessToken
+    ){}
+
     // 개인정보
     public record PersonalInfoResponseDto(
             String name,
             String email,
             String phoneNumber,
             LocalDate birthDate
-    ) {
-    }
+    ) {}
 }

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
@@ -11,7 +11,12 @@ public enum UserErrorCode implements BaseErrorCode {
 
     // 로그인
     INVALID(HttpStatus.UNAUTHORIZED, "AUTH4001", "이메일 또는 비밀번호가 올바르지 않습니다."),
-    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH4004", "이미 사용 중인 아이디입니다."),
+    EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "AUTH4002", "이미 사용 중인 아이디입니다."),
+
+    // 리프레쉬 토큰
+    REFRESH_TOKEN_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH4003", "리프레시 토큰이 필요합니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH4004", "리프레시 토큰이 유효하지 않습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4005", "리프레시 토큰이 만료되었습니다."),
 
     // 비밀번호
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER4001", "비밀번호는 8~12자, 영문+특수문자 조합이어야 합니다."),

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
@@ -12,6 +12,7 @@ public enum UserSuccessCode implements BaseSuccessCode {
     EMAIL_CHECK_OK(HttpStatus.OK, "AUTH2000", "아이디 중복 확인에 성공했습니다."),
     CREATED(HttpStatus.CREATED, "AUTH2001", "회원가입이 성공적으로 완료되었습니다."),
     LOGIN_OK(HttpStatus.OK, "AUTH2002", "로그인에 성공했습니다."),
+    TOKEN_REFRESH_OK(HttpStatus.OK, "AUTH2003", "액세스 토큰 재발급에 성공했습니다."),
 
     PERSONAL_INFO_OK(HttpStatus.OK, "USER2000", "개인정보 조회에 성공했습니다."),
     BIRTH_DATE_UPDATED(HttpStatus.OK, "USER2001", "생년월일 변경에 성공했습니다."),

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
@@ -13,6 +13,7 @@ public enum UserSuccessCode implements BaseSuccessCode {
     CREATED(HttpStatus.CREATED, "AUTH2001", "회원가입이 성공적으로 완료되었습니다."),
     LOGIN_OK(HttpStatus.OK, "AUTH2002", "로그인에 성공했습니다."),
     TOKEN_REFRESH_OK(HttpStatus.OK, "AUTH2003", "액세스 토큰 재발급에 성공했습니다."),
+    LOGOUT_OK(HttpStatus.OK, "AUTH2004", "로그아웃에 성공했습니다."),
 
     PERSONAL_INFO_OK(HttpStatus.OK, "USER2000", "개인정보 조회에 성공했습니다."),
     BIRTH_DATE_UPDATED(HttpStatus.OK, "USER2001", "생년월일 변경에 성공했습니다."),

--- a/src/main/java/com/umc/barkit/domain/user/repository/UserSessionRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/UserSessionRepository.java
@@ -1,9 +1,12 @@
 package com.umc.barkit.domain.user.repository;
 
+import com.umc.barkit.domain.user.entity.User;
 import com.umc.barkit.domain.user.entity.UserSession;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
+    Optional<UserSession> findByUserAndRefreshTokenHash(User user, String refreshTokenHash);
 }

--- a/src/main/java/com/umc/barkit/domain/user/repository/UserSessionRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/UserSessionRepository.java
@@ -2,11 +2,16 @@ package com.umc.barkit.domain.user.repository;
 
 import com.umc.barkit.domain.user.entity.User;
 import com.umc.barkit.domain.user.entity.UserSession;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
-    Optional<UserSession> findByUserAndRefreshTokenHash(User user, String refreshTokenHash);
+    Optional<UserSession> findByUserAndRefreshTokenHashAndRevokedAtIsNull(User user, String refreshTokenHash);
+
 }

--- a/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
@@ -81,6 +81,45 @@ public class UserQueryService {
         userSessionRepository.save(userSession); // DB에 저장
     }
 
+    // 엑세스 토큰 재발급
+    public String refreshAccessToken(String refreshToken) {
+        // 요청 바디에 리프레쉬 토큰이 없으면 재발급 자체가 불가능
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_REQUIRED);
+        }
+
+        // JWT 서명/만료 등 기본 유효성 검증
+        if (!jwtUtil.isValid(refreshToken)) {
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        // 리프레쉬 토큰의 subject(email)로 사용자 식별
+        String email = jwtUtil.getEmail(refreshToken);
+        if (email == null || email.isBlank()) {
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        // 이메일로 User 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        // 리프레쉬 토큰 해시화
+        String refreshTokenHash = jwtUtil.hashToken(refreshToken);
+
+        // 세션 존재 여부 확인
+        UserSession session = userSessionRepository.findByUserAndRefreshTokenHash(user, refreshTokenHash)
+                .orElseThrow(() -> new UserException(UserErrorCode.REFRESH_TOKEN_INVALID));
+
+        // DB에 저장된 만료 시간 기준으로 세션 만료 여부 확인
+        if (session.getExpiresAt().isBefore(LocalDateTime.now())) {
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
+
+        // 새 엑세스 토큰 발급
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+        return jwtUtil.createAccessToken(userDetails);
+    }
+
     // 개인정보 조회
     public UserResponseDto.PersonalInfoResponseDto getPersonalInfo(Long userId) {
         User user = userRepository.findById(userId)

--- a/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
@@ -17,6 +17,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -35,6 +36,7 @@ public class UserQueryService {
     }
 
     // 로그인
+    @Transactional
     public UserResponseDto.LoginResponseDto login(
             UserRequestDto.@Valid LoginRequestDto dto
     ) {
@@ -82,6 +84,7 @@ public class UserQueryService {
     }
 
     // 엑세스 토큰 재발급
+    @Transactional
     public String refreshAccessToken(String refreshToken) {
         // 요청 바디에 리프레쉬 토큰이 없으면 재발급 자체가 불가능
         if (refreshToken == null || refreshToken.isBlank()) {
@@ -107,13 +110,15 @@ public class UserQueryService {
         String refreshTokenHash = jwtUtil.hashToken(refreshToken);
 
         // 세션 존재 여부 확인
-        UserSession session = userSessionRepository.findByUserAndRefreshTokenHash(user, refreshTokenHash)
+        UserSession session = userSessionRepository.findByUserAndRefreshTokenHashAndRevokedAtIsNull(user, refreshTokenHash)
                 .orElseThrow(() -> new UserException(UserErrorCode.REFRESH_TOKEN_INVALID));
 
         // DB에 저장된 만료 시간 기준으로 세션 만료 여부 확인
         if (session.getExpiresAt().isBefore(LocalDateTime.now())) {
             throw new UserException(UserErrorCode.REFRESH_TOKEN_EXPIRED);
         }
+
+        session.touch();
 
         // 새 엑세스 토큰 발급
         CustomUserDetails userDetails = new CustomUserDetails(user);
@@ -130,5 +135,32 @@ public class UserQueryService {
         }
 
         return UserConverter.toPersonalInfoDto(user);
+    }
+
+    // 로그아웃
+    @Transactional
+    public void logout(String refreshToken) {
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_REQUIRED);
+        }
+
+        if (!jwtUtil.isValid(refreshToken)) {
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        String email = jwtUtil.getEmail(refreshToken);
+        if (email == null || email.isBlank()) {
+            throw new UserException(UserErrorCode.REFRESH_TOKEN_INVALID);
+        }
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        String refreshTokenHash = jwtUtil.hashToken(refreshToken);
+
+        UserSession session = userSessionRepository.findByUserAndRefreshTokenHashAndRevokedAtIsNull(user, refreshTokenHash)
+                .orElseThrow(() -> new UserException(UserErrorCode.REFRESH_TOKEN_INVALID));
+
+        session.revoke();
     }
 }

--- a/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
@@ -26,8 +26,10 @@ public class SecurityConfig{
 
     private final String[] allowUris = {
             "/**", // 모든 요청에 대해 인증 없이 접근 허용
-            "api/auth/login",
-            "api/auth/signup",
+            "/api/auth/login",
+            "/api/auth/signup",
+            "/api/auth/check-email",
+            "/api/auth/refresh",
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",

--- a/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig{
             "/api/auth/signup",
             "/api/auth/check-email",
             "/api/auth/refresh",
+            "/api/auth/logout",
             "/swagger-ui/**",
             "/swagger-resources/**",
             "/v3/api-docs/**",


### PR DESCRIPTION
## #️⃣ 기능 설명
* Refresh Token을 이용한 Access Token 재발급 API 구현
* Refresh Token 기반 로그아웃(세션 무효화) API 구현

## 🛠️ 작업 상세 내용
- [x] Access Token 재발급 API 
* 요청 바디로 Refresh Token을 전달받아 JWT 유효성(서명/만료) 검증
* DB user_sessions의 refresh_token_hash와 매칭하여 세션 유효성 검증
* 재발급 성공 시 last_used_at 업데이트 후 새로운 Access Token 반환
- [x] 로그아웃 AP
* 요청 바디로 Refresh Token을 전달받아 검증 후 해당 세션 revoked_at 설정(무효화)
* 로그아웃 이후 동일 Refresh Token으로 재발급 불가

## 📸 스크린샷 (선택)
1. 로그인 성공
<img width="911" height="721" alt="image" src="https://github.com/user-attachments/assets/e247bbce-bb97-4b50-aa72-963465cb7db4" />
<img width="870" height="246" alt="image" src="https://github.com/user-attachments/assets/88891402-e20c-486c-8541-d227c3e91a2f" />

2. AccessToken 만료 상황 가정하고 재발급
<img width="913" height="722" alt="image" src="https://github.com/user-attachments/assets/7de69aad-1c35-4420-a796-f9a51032f7e3" />
<img width="874" height="191" alt="image" src="https://github.com/user-attachments/assets/5fc5920b-065e-407c-9e06-1292dac0889d" />

3. 재발급한 액세스 토큰으로 개인정보 조회 테스트
<img width="875" height="206" alt="image" src="https://github.com/user-attachments/assets/aae2cb7a-ec97-4e6d-b138-932396b8994a" />

4. 로그아웃
<img width="910" height="752" alt="image" src="https://github.com/user-attachments/assets/89095c4c-ca1d-4693-b271-8d238ece7f0c" />
<img width="874" height="138" alt="image" src="https://github.com/user-attachments/assets/b61c2908-aa79-42d3-a58b-ce9ba42b8f9b" />

5. 무효화 된 리프레쉬 토큰으로 액세스 토큰 재발급 테스트
<img width="911" height="719" alt="image" src="https://github.com/user-attachments/assets/8537d2f7-1f32-4101-83a2-db8417cc1e0f" />
<img width="873" height="155" alt="image" src="https://github.com/user-attachments/assets/f81e9fc8-918d-45e2-bfdd-61e648a316f2" />

6. 세션테이블에 무효화가 잘 처리된 모습
<img width="1406" height="36" alt="image" src="https://github.com/user-attachments/assets/cbbc02a9-709a-495d-9a97-95695bf1088c" />

## 💬 기타(공유사항 to 리뷰어)
* Access Token 만료시간은 1시간, Refresh Token 만료시간은 30일로 설정했습니다.