### PR TITLE
✨ [Feat] 멤버십 브랜드 기본 10개 노출 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/MembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/MembershipBrandController.java
@@ -3,13 +3,15 @@ package com.umc.barkit.domain.membership.controller;
 import com.umc.barkit.domain.membership.dto.response.MembershipBrandResponseDTO;
 import com.umc.barkit.domain.membership.service.MembershipBrandQueryService;
 import com.umc.barkit.global.apiPayload.ApiResponse;
+import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
 import com.umc.barkit.global.apiPayload.code.GeneralSuccessCode;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
+import com.umc.barkit.global.auth.details.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
-
 import io.swagger.v3.oas.annotations.Parameter;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -22,28 +24,40 @@ public class MembershipBrandController {
 
     private final MembershipBrandQueryService membershipBrandQueryService;
 
-    // GET /api/membership-brands/top4
     @Operation(
-            summary = "상위 4개 인기 멤버십 브랜드 조회",
-            description = "등록 수가 많은 상위 4개 멤버십 브랜드를 조회합니다. 브랜드 ID, 이름, 로고 URL을 포함합니다."
+            summary = "멤버십 브랜드 기본 10개 노출",
+            description = "브랜드 ID, 이름, 로고 URL을 포함합니다."
     )
-    @GetMapping("/top4")
-    public ResponseEntity<ApiResponse<MembershipBrandResponseDTO.Top4BrandsDTO>> getTop4MembershipBrands() {
-        MembershipBrandResponseDTO.Top4BrandsDTO result =
-                membershipBrandQueryService.getTop4MembershipBrands();
+    @GetMapping("/default")
+    public ResponseEntity<ApiResponse<MembershipBrandResponseDTO.DefaultBrandsDTO>> getDefaultMembershipBrands(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        // JWT 인증 체크
+        if (userDetails == null) {
+            throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
+        }
+
+        MembershipBrandResponseDTO.DefaultBrandsDTO result =
+                membershipBrandQueryService.getDefaultMembershipBrands();
 
         return ResponseEntity
                 .status(GeneralSuccessCode.OK.getStatus())
                 .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
     }
 
-    // GET /api/membership-brands/popular
     @Operation(
             summary = "인기 멤버십 브랜드 10개 조회",
             description = "등록 수가 많은 상위 10개 멤버십 브랜드를 조회합니다. 브랜드 ID와 이름만 포함합니다."
     )
     @GetMapping("/popular")
-    public ResponseEntity<ApiResponse<MembershipBrandResponseDTO.PopularBrandsDTO>> getPopularMembershipBrands() {
+    public ResponseEntity<ApiResponse<MembershipBrandResponseDTO.PopularBrandsDTO>> getPopularMembershipBrands(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        // JWT 인증 체크
+        if (userDetails == null) {
+            throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
+        }
+
         MembershipBrandResponseDTO.PopularBrandsDTO result =
                 membershipBrandQueryService.getPopularMembershipBrands();
 
@@ -60,6 +74,8 @@ public class MembershipBrandController {
     )
     @GetMapping("/search")
     public ResponseEntity<ApiResponse<MembershipBrandResponseDTO.SearchResultDTO>> searchMembershipBrands(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+
             @Parameter(description = "검색 키워드 (대소문자 무시, 부분 일치)", required = true)
             @RequestParam String keyword,
 
@@ -69,6 +85,11 @@ public class MembershipBrandController {
             @Parameter(description = "한 번에 가져올 개수 (기본값: 20)", required = false, example = "20")
             @RequestParam(required = false) Integer limit
     ) {
+        // JWT 인증 체크
+        if (userDetails == null) {
+            throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
+        }
+
         MembershipBrandResponseDTO.SearchResultDTO result =
                 membershipBrandQueryService.searchMembershipBrands(keyword, cursor, limit);
 

--- a/src/main/java/com/umc/barkit/domain/membership/converter/MembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/MembershipBrandConverter.java
@@ -25,11 +25,11 @@ public class MembershipBrandConverter {
                 .collect(Collectors.toList());
     }
 
-    // MembershipBrand Entity List -> Top4BrandsDTO 변환
-    public static MembershipBrandResponseDTO.Top4BrandsDTO toTop4BrandsDTO(List<MembershipBrand> membershipBrands) {
+    // MembershipBrand Entity List -> DefaultBrandsDTO 변환
+    public static MembershipBrandResponseDTO.DefaultBrandsDTO toDefaultBrandsDTO(List<MembershipBrand> membershipBrands) {
         List<MembershipBrandResponseDTO.BrandSimpleDTO> brandDTOs = toBrandSimpleDTOList(membershipBrands);
 
-        return MembershipBrandResponseDTO.Top4BrandsDTO.builder()
+        return MembershipBrandResponseDTO.DefaultBrandsDTO.builder()
                 .brands(brandDTOs)
                 .build();
     }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -87,10 +87,3 @@ public class UserMembershipBrandConverter {
                 .build();
     }
 }
-
-
-
-
-
-
-

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/MembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/MembershipBrandResponseDTO.java
@@ -9,12 +9,12 @@ import java.util.List;
 
 public class MembershipBrandResponseDTO {
 
-    // 상위 4개 멤버십 브랜드 조회 응답 DTO
+    // 기본 10개 멤버십 브랜드 조회 응답 DTO
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class Top4BrandsDTO {
+    public static class DefaultBrandsDTO {
         private List<BrandSimpleDTO> brands;
     }
 

--- a/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipErrorCode.java
@@ -20,18 +20,14 @@ public enum MembershipErrorCode implements BaseErrorCode {
     MEMBERSHIP4004(HttpStatus.NOT_FOUND,"MEMBERSHIP4004","등록된 사용자 멤버십이 존재하지 않습니다."),
     MEMBERSHIP4006(HttpStatus.FORBIDDEN, "MEMBERSHIP4006", "본인의 멤버십만 대표 멤버십으로 설정할 수 있습니다."),
     MEMBERSHIP4007(HttpStatus.BAD_REQUEST, "MEMBERSHIP4007", "대표 멤버십은 최대 3개까지 설정할 수 있습니다."),
-    // ========== 바코드 에러 (BARCODE) ==========
-    BARCODE4001(HttpStatus.BAD_REQUEST, "BARCODE4001", "지원하지 않는 바코드 형식입니다."),
+    MEMBERSHIP4008(HttpStatus.BAD_REQUEST, "MEMBERSHIP4008", "멤버십 번호는 최소 12자 이상이어야 합니다."),
+    MEMBERSHIP4009(HttpStatus.CONFLICT, "MEMBERSHIP4009", "이미 저장된 멤버십 브랜드입니다."),
 
-    // ========== 사진 에러 (PHOTO) ==========
-    PHOTO4001(HttpStatus.BAD_REQUEST, "PHOTO4001", "사진을 업로드해주세요."),
-    PHOTO4002(HttpStatus.BAD_REQUEST, "PHOTO4002", "사진 크기는 최대 10MB까지 가능합니다."),
-    PHOTO4003(HttpStatus.BAD_REQUEST, "PHOTO4003", "jpg, png 형식만 업로드 가능합니다."),
-    PHOTO4004(HttpStatus.BAD_REQUEST, "PHOTO4004", "이미지 파일이 손상되었거나 읽을 수 없습니다.");
+    // ========== 바코드 에러 (BARCODE) ==========
+    BARCODE4001(HttpStatus.BAD_REQUEST, "BARCODE4001", "지원하지 않는 바코드 형식입니다.");
 
     private final HttpStatus status;
     private final String code;
     private final String message;
-
 
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepositoryCustom.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepositoryCustom.java
@@ -6,8 +6,8 @@ import java.util.List;
 
 public interface MembershipBrandRepositoryCustom {
 
-    // 상위 4개 인기 멤버십 브랜드 조회 (QueryDSL)
-    List<MembershipBrand> findTop4ByRegistrationCount();
+    // 기본 10개 멤버십 브랜드 조회 (QueryDSL)
+    List<MembershipBrand> findTop10ByRegistrationCountForDefault();
 
     // 인기 멤버십 브랜드 10개 조회 (QueryDSL)
     List<MembershipBrand> findTop10ByRegistrationCount();

--- a/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/MembershipBrandRepositoryImpl.java
@@ -31,7 +31,7 @@ public class MembershipBrandRepositoryImpl implements MembershipBrandRepositoryC
     }};
 
     @Override
-    public List<MembershipBrand> findTop4ByRegistrationCount() {
+    public List<MembershipBrand> findTop10ByRegistrationCountForDefault() {
         return queryFactory
                 .selectFrom(membershipBrand)
                 .leftJoin(userMembershipBrand)
@@ -41,7 +41,7 @@ public class MembershipBrandRepositoryImpl implements MembershipBrandRepositoryC
                         userMembershipBrand.count().desc(),
                         membershipBrand.id.asc()
                 )
-                .limit(4)
+                .limit(10)
                 .fetch();
     }
 

--- a/src/main/java/com/umc/barkit/domain/membership/service/MembershipBrandQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/MembershipBrandQueryService.java
@@ -4,8 +4,8 @@ import com.umc.barkit.domain.membership.dto.response.MembershipBrandResponseDTO;
 
 public interface MembershipBrandQueryService {
 
-    // 상위 4개 인기 멤버십 브랜드 조회
-    MembershipBrandResponseDTO.Top4BrandsDTO getTop4MembershipBrands();
+    // 기본 10개 멤버십 브랜드 조회
+    MembershipBrandResponseDTO.DefaultBrandsDTO getDefaultMembershipBrands();
 
     // 인기 멤버십 브랜드 10개 조회
     MembershipBrandResponseDTO.PopularBrandsDTO getPopularMembershipBrands();

--- a/src/main/java/com/umc/barkit/domain/membership/service/MembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/MembershipBrandQueryServiceImpl.java
@@ -18,9 +18,9 @@ public class MembershipBrandQueryServiceImpl implements MembershipBrandQueryServ
     private final MembershipBrandRepository membershipBrandRepository;
 
     @Override
-    public MembershipBrandResponseDTO.Top4BrandsDTO getTop4MembershipBrands() {
-        List<MembershipBrand> top4Brands = membershipBrandRepository.findTop4ByRegistrationCount();
-        return MembershipBrandConverter.toTop4BrandsDTO(top4Brands);
+    public MembershipBrandResponseDTO.DefaultBrandsDTO getDefaultMembershipBrands() {
+        List<MembershipBrand> defaultBrands = membershipBrandRepository.findTop10ByRegistrationCountForDefault();
+        return MembershipBrandConverter.toDefaultBrandsDTO(defaultBrands);
     }
 
     @Override


### PR DESCRIPTION
## #️⃣ 기능 설명
> 멤버십 브랜드 기본 10개 노출 API 구현 - GET /api/membership-brands/default
> 멤버십 브랜드 관련 API에 JWT 인증 방식 적용

## 🛠️ 작업 상세 내용
- [x] 기존 상위 4개 인기 멤버십 브랜드 조회 API 구현 부분 제거
- [x] DefaultBrandsDTO Response DTO 추가
- [x] toDefaultBrandsDTO Converter 메서드 추가
- [x] getDefaultMembershipBrands Service 메서드 추가
- [x] 기존 findTop10ByRegistrationCount() Repository 메서드 재사용
- [x] 멤버십 브랜드 관련 API에 JWT 인증 방식 적용 : /default, /popular, /search
- [x] 인증 실패 시 COMMON4001 에러 처리

## 📸 스크린샷 (선택)
<img width="872" height="303" alt="스크린샷 2026-02-05 오전 6 12 12" src="https://github.com/user-attachments/assets/05b0b99a-fb18-4b85-98b8-747903e4e968" />

## 💬 기타(공유사항 to 리뷰어)