### PR TITLE
[Feat] 사용자의 멤버십 기준 적립/할인 가능 매장 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -132,4 +132,34 @@ public class UserMembershipBrandController {
                 .status(successCode.getStatus())
                 .body(ApiResponse.onSuccess(successCode, null));
     }
+
+    @Operation(
+            summary = "멤버십 기준 적립/할인 가능 매장 조회",
+            description = "로그인한 사용자가 보유한 특정 멤버십으로 적립/할인 가능한 매장 목록을 조회합니다. " +
+                    "검색어(keyword)를 통해 매장명 검색이 가능합니다."
+    )
+    @GetMapping("/{userMembershipBrandId}/stores")
+    public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.AvailableStoreListDTO>> getAvailableStores(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long userMembershipBrandId,
+            @RequestParam(required = false) String keyword
+    ) {
+        if (userDetails == null) {
+            throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
+        }
+
+        Long userId = userDetails.getUserId();
+
+        UserMembershipBrandResponseDTO.AvailableStoreListDTO result =
+                userMembershipBrandQueryService.getAvailableStores(
+                        userId,
+                        userMembershipBrandId,
+                        keyword
+                );
+
+        return ResponseEntity
+                .status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
+    }
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -136,13 +136,15 @@ public class UserMembershipBrandController {
     @Operation(
             summary = "멤버십 기준 적립/할인 가능 매장 조회",
             description = "로그인한 사용자가 보유한 특정 멤버십으로 적립/할인 가능한 매장 목록을 조회합니다. " +
-                    "검색어(keyword)를 통해 매장명 검색이 가능합니다."
+                    "검색어(keyword)를 통해 매장명 검색이 가능하며, cursor 기반 페이징을 지원합니다."
     )
     @GetMapping("/{userMembershipBrandId}/stores")
     public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.AvailableStoreListDTO>> getAvailableStores(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long userMembershipBrandId,
-            @RequestParam(required = false) String keyword
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(required = false) Integer size
     ) {
         if (userDetails == null) {
             throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
@@ -154,12 +156,13 @@ public class UserMembershipBrandController {
                 userMembershipBrandQueryService.getAvailableStores(
                         userId,
                         userMembershipBrandId,
-                        keyword
+                        keyword,
+                        cursor,
+                        size
                 );
 
         return ResponseEntity
                 .status(GeneralSuccessCode.OK.getStatus())
                 .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
     }
-
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -90,30 +90,19 @@ public class UserMembershipBrandConverter {
     }
 
     /* =========================
-       사용 가능 매장 조회 (Google Place 반영)
+       사용 가능 매장 조회
      ========================= */
-
     public UserMembershipBrandResponseDTO.AvailableStoreDTO
-    toAvailableStoreDTO(
-            Store store,
-            GooglePlaceDTO.Place place
-    ) {
+    toAvailableStoreDTO(Store store) {
+
         StoreBrand brand = store.getBrand();
 
         return UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
                 .storeId(store.getId())
-                .storeName(
-                        place != null
-                                ? place.displayName().text()
-                                : brand.getName()
-                )
+                .storeName(brand.getName())   // 아직 지점명 없음
                 .brandName(brand.getName())
                 .logoUrl(brand.getLogoUrl())
-                .address(
-                        place != null
-                                ? place.formattedAddress()
-                                : null
-                )
+                .address(null)                // 1단계: null
                 .build();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -90,7 +90,7 @@ public class UserMembershipBrandConverter {
     }
 
     /* =========================
-       사용 가능 매장 조회
+       사용 가능 매장 조회(브랜드)
      ========================= */
     public UserMembershipBrandResponseDTO.AvailableStoreDTO
     toAvailableStoreDTO(Store store) {
@@ -98,11 +98,11 @@ public class UserMembershipBrandConverter {
         StoreBrand brand = store.getBrand();
 
         return UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
-                .storeId(store.getId())
-                //.storeName(brand.getName())   // 아직 지점명 없음
-                .brandName(brand.getName())
+                .storeId(store.getId())          // 내부용 (cursor용)
+                //.storeName(null)               // 지점명 없음
+                .brandName(brand.getName())      // 브랜드명
                 .logoUrl(brand.getLogoUrl())
-                .address(null)                // 1단계: null
+                //.address(null)
                 .build();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -8,6 +8,7 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.exception.MembershipException;
 import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
+import com.umc.barkit.domain.store.dto.google.GooglePlaceDTO;
 import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.domain.store.entity.Store;
 import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
@@ -89,20 +90,30 @@ public class UserMembershipBrandConverter {
     }
 
     /* =========================
-       사용 가능 매장 조회
+       사용 가능 매장 조회 (Google Place 반영)
      ========================= */
 
     public UserMembershipBrandResponseDTO.AvailableStoreDTO
-    toAvailableStoreDTO(Store store) {
-
+    toAvailableStoreDTO(
+            Store store,
+            GooglePlaceDTO.Place place
+    ) {
         StoreBrand brand = store.getBrand();
 
         return UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
                 .storeId(store.getId())
-                .storeName(brand.getName())
+                .storeName(
+                        place != null
+                                ? place.displayName().text()
+                                : brand.getName()
+                )
                 .brandName(brand.getName())
                 .logoUrl(brand.getLogoUrl())
-                .address(null) // TODO: Google Place 연동 시 주소 추가
+                .address(
+                        place != null
+                                ? place.formattedAddress()
+                                : null
+                )
                 .build();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -8,12 +8,13 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.exception.MembershipException;
 import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
+import com.umc.barkit.domain.store.entity.StoreBrand;
+import com.umc.barkit.domain.store.entity.Store;
 import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
 import com.umc.barkit.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import com.umc.barkit.domain.membership.dto.response.MembershipBrandResponseDTO;
-import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -84,6 +85,24 @@ public class UserMembershipBrandConverter {
                 .membershipNumber(umb.getMembershipNumber())
                 .logoUrl(brand.getLogoUrl())
                 .brandName(brand.getName())
+                .build();
+    }
+
+    /* =========================
+       사용 가능 매장 조회
+     ========================= */
+
+    public UserMembershipBrandResponseDTO.AvailableStoreDTO
+    toAvailableStoreDTO(Store store) {
+
+        StoreBrand brand = store.getBrand();
+
+        return UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
+                .storeId(store.getId())
+                .storeName(brand.getName())
+                .brandName(brand.getName())
+                .logoUrl(brand.getLogoUrl())
+                .address(null) // TODO: Google Place 연동 시 주소 추가
                 .build();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -99,7 +99,7 @@ public class UserMembershipBrandConverter {
 
         return UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
                 .storeId(store.getId())
-                .storeName(brand.getName())   // 아직 지점명 없음
+                //.storeName(brand.getName())   // 아직 지점명 없음
                 .brandName(brand.getName())
                 .logoUrl(brand.getLogoUrl())
                 .address(null)                // 1단계: null

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -52,6 +52,8 @@ public class UserMembershipBrandResponseDTO {
     @AllArgsConstructor
     public static class AvailableStoreListDTO {
         private List<AvailableStoreDTO> stores;
+        private Boolean hasNext;
+        private Long nextCursor;
     }
 
     @Getter

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -45,4 +45,25 @@ public class UserMembershipBrandResponseDTO {
         private String logoUrl;
         private String brandName;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AvailableStoreListDTO {
+        private List<AvailableStoreDTO> stores;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AvailableStoreDTO {
+        private Long storeId;
+        private String storeName;
+        private String brandName;
+        private String logoUrl;
+        private String address; // 지금은 null
+    }
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -62,10 +62,8 @@ public class UserMembershipBrandResponseDTO {
     @AllArgsConstructor
     public static class AvailableStoreDTO {
         private Long storeId;
-        private String storeName;
         private String brandName;
         private String logoUrl;
-        private String address; // 지금은 null
     }
 
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
@@ -17,7 +17,9 @@ public interface UserMembershipBrandQueryService {
     UserMembershipBrandResponseDTO.AvailableStoreListDTO getAvailableStores(
             Long userId,
             Long userMembershipBrandId,
-            String keyword
+            String keyword,
+            Long cursor,
+            Integer size
     );
 
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
@@ -14,4 +14,10 @@ public interface UserMembershipBrandQueryService {
 
     UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO getUserMembershipBarcode(Long userId,Long membershipBrandId);
 
+    UserMembershipBrandResponseDTO.AvailableStoreListDTO getAvailableStores(
+            Long userId,
+            Long userMembershipBrandId,
+            String keyword
+    );
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -111,7 +111,7 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
         // 0. pageSize 보정 로직 (여기!)
         int pageSize = (size == null || size <= 0) ? 20 : size;
 
-        Pageable pageable = PageRequest.of(0, pageSize);
+        Pageable pageable = PageRequest.of(0, pageSize + 1);
 
         // 1. 사용자 멤버십 검증
         UserMembershipBrand umb =
@@ -147,15 +147,29 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
                         cursor,
                         pageable
                 );
+        // 다음 페이지 존재 여부
+        boolean hasNext = stores.size() > pageSize;
+
+        // 실제 반환할 데이터
+        List<Store> resultStores = hasNext
+                ? stores.subList(0, pageSize)
+                : stores;
+
+        // nextCursor 계산
+        Long nextCursor = hasNext
+                ? resultStores.get(resultStores.size() - 1).getId()
+                : null;
 
         // 5. DTO 변환
         List<UserMembershipBrandResponseDTO.AvailableStoreDTO> storeDTOs =
-                stores.stream()
-                        .map(store -> userMembershipBrandConverter.toAvailableStoreDTO(store))
+                resultStores.stream()
+                        .map(userMembershipBrandConverter::toAvailableStoreDTO)
                         .toList();
 
         return UserMembershipBrandResponseDTO.AvailableStoreListDTO.builder()
                 .stores(storeDTOs)
+                .hasNext(hasNext)
+                .nextCursor(nextCursor)
                 .build();
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -12,8 +12,10 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
 import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.domain.store.repository.StoreBrandMembershipBrandRepository;
 import com.umc.barkit.domain.store.entity.Store;
+import com.umc.barkit.domain.store.repository.StoreBrandRepository;
 import com.umc.barkit.domain.store.repository.StoreRepository;
 import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
 import com.umc.barkit.domain.store.external.google.GoogleMapSearchClient;
@@ -26,8 +28,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import com.umc.barkit.domain.membership.exception.MembershipException;
 
@@ -44,6 +46,7 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
     private final StoreBrandMembershipBrandRepository storeBrandMembershipBrandRepository;
     private final StoreRepository storeRepository;
     private final GoogleMapSearchClient googleMapSearchClient;
+    private final StoreBrandRepository storeBrandRepository;
 
     @Override
     public UserMembershipBrandResponseDTO.SearchResultDTO searchUserMembershipBrands(
@@ -100,29 +103,23 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
     }
 
     @Override
-    public UserMembershipBrandResponseDTO.AvailableStoreListDTO
-    getAvailableStores(
+    public UserMembershipBrandResponseDTO.AvailableStoreListDTO getAvailableStores(
             Long userId,
             Long userMembershipBrandId,
             String keyword,
             Long cursor,
             Integer size
     ) {
-        // 0. pageSize 보정 로직 (여기!)
         int pageSize = (size == null || size <= 0) ? 20 : size;
-
-        Pageable pageable = PageRequest.of(0, pageSize + 1);
 
         // 1. 사용자 멤버십 검증
         UserMembershipBrand umb =
                 userMembershipBrandRepository.findById(userMembershipBrandId)
                         .orElseThrow(() ->
-                                new MembershipException(
-                                        MembershipErrorCode.MEMBERSHIP4001));
+                                new MembershipException(MembershipErrorCode.MEMBERSHIP4001));
 
         if (!umb.getUserId().equals(userId)) {
-            throw new MembershipException(
-                    MembershipErrorCode.MEMBERSHIP4003);
+            throw new MembershipException(MembershipErrorCode.MEMBERSHIP4003);
         }
 
         // 2. 멤버십 브랜드 ID
@@ -136,34 +133,45 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
         if (storeBrandIds.isEmpty()) {
             return UserMembershipBrandResponseDTO.AvailableStoreListDTO.builder()
                     .stores(List.of())
+                    .hasNext(false)
+                    .nextCursor(null)
                     .build();
         }
 
-        // 4. Store 조회 (cursor + size + keyword)
-        List<Store> stores =
-                storeRepository.findStoresByStoreBrandIdsAndKeyword(
+        // 4. StoreBrand 조회 (지점 존재하는 브랜드만)
+        List<StoreBrand> brands =
+                storeBrandRepository.findAvailableStoreBrands(
                         storeBrandIds,
                         keyword,
                         cursor,
-                        pageable
+                        PageRequest.of(0, pageSize + 1)
                 );
-        // 다음 페이지 존재 여부
-        boolean hasNext = stores.size() > pageSize;
 
-        // 실제 반환할 데이터
-        List<Store> resultStores = hasNext
-                ? stores.subList(0, pageSize)
-                : stores;
+        boolean hasNext = brands.size() > pageSize;
 
-        // nextCursor 계산
+        List<StoreBrand> resultBrands = hasNext
+                ? brands.subList(0, pageSize)
+                : brands;
+
         Long nextCursor = hasNext
-                ? resultStores.get(resultStores.size() - 1).getId()
+                ? resultBrands.get(resultBrands.size() - 1).getId()
                 : null;
 
-        // 5. DTO 변환
+        // 5. DTO 변환 (대표 store 1개만 사용)
         List<UserMembershipBrandResponseDTO.AvailableStoreDTO> storeDTOs =
-                resultStores.stream()
-                        .map(userMembershipBrandConverter::toAvailableStoreDTO)
+                resultBrands.stream()
+                        .map(brand -> {
+                            Long storeId =
+                                    storeRepository
+                                            .findStoreIdsByBrandId(brand.getId(), PageRequest.of(0, 1))
+                                            .get(0);
+
+                            return UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
+                                    .storeId(storeId)
+                                    .brandName(brand.getName())
+                                    .logoUrl(brand.getLogoUrl())
+                                    .build();
+                        })
                         .toList();
 
         return UserMembershipBrandResponseDTO.AvailableStoreListDTO.builder()
@@ -172,4 +180,5 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
                 .nextCursor(nextCursor)
                 .build();
     }
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -20,6 +20,8 @@ import com.umc.barkit.domain.store.external.google.GoogleMapSearchClient;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -99,22 +101,34 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
 
     @Override
     public UserMembershipBrandResponseDTO.AvailableStoreListDTO
-    getAvailableStores(Long userId, Long userMembershipBrandId, String keyword) {
+    getAvailableStores(
+            Long userId,
+            Long userMembershipBrandId,
+            String keyword,
+            Long cursor,
+            Integer size
+    ) {
+        // 0. pageSize 보정 로직 (여기!)
+        int pageSize = (size == null || size <= 0) ? 20 : size;
+
+        Pageable pageable = PageRequest.of(0, pageSize);
 
         // 1. 사용자 멤버십 검증
         UserMembershipBrand umb =
                 userMembershipBrandRepository.findById(userMembershipBrandId)
                         .orElseThrow(() ->
-                                new MembershipException(MembershipErrorCode.MEMBERSHIP4001));
+                                new MembershipException(
+                                        MembershipErrorCode.MEMBERSHIP4001));
 
         if (!umb.getUserId().equals(userId)) {
-            throw new MembershipException(MembershipErrorCode.MEMBERSHIP4003);
+            throw new MembershipException(
+                    MembershipErrorCode.MEMBERSHIP4003);
         }
 
         // 2. 멤버십 브랜드 ID
         Long membershipBrandId = umb.getMembershipBrandId();
 
-        // 3. 멤버십 → StoreBrand ID 목록
+        // 3. 멤버십 → StoreBrand IDs
         List<Long> storeBrandIds =
                 storeBrandMembershipBrandRepository
                         .findStoreBrandIdsByMembershipBrandId(membershipBrandId);
@@ -125,23 +139,19 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
                     .build();
         }
 
-        // 4. Store 조회
+        // 4. Store 조회 (cursor + size + keyword)
         List<Store> stores =
                 storeRepository.findStoresByStoreBrandIdsAndKeyword(
-                        storeBrandIds, keyword
+                        storeBrandIds,
+                        keyword,
+                        cursor,
+                        pageable
                 );
 
-        // 5. Google Place 연동 + DTO 변환 (🔥 핵심)
+        // 5. DTO 변환
         List<UserMembershipBrandResponseDTO.AvailableStoreDTO> storeDTOs =
                 stores.stream()
-                        .map(store -> {
-                            var place =
-                                    googleMapSearchClient
-                                            .getPlaceDetail(store.getGoogleId());
-
-                            return userMembershipBrandConverter
-                                    .toAvailableStoreDTO(store, place);
-                        })
+                        .map(store -> userMembershipBrandConverter.toAvailableStoreDTO(store))
                         .toList();
 
         return UserMembershipBrandResponseDTO.AvailableStoreListDTO.builder()

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -16,6 +16,7 @@ import com.umc.barkit.domain.store.repository.StoreBrandMembershipBrandRepositor
 import com.umc.barkit.domain.store.entity.Store;
 import com.umc.barkit.domain.store.repository.StoreRepository;
 import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+import com.umc.barkit.domain.store.external.google.GoogleMapSearchClient;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,7 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
     private final MembershipBrandRepository membershipBrandRepository;
     private final StoreBrandMembershipBrandRepository storeBrandMembershipBrandRepository;
     private final StoreRepository storeRepository;
+    private final GoogleMapSearchClient googleMapSearchClient;
 
     @Override
     public UserMembershipBrandResponseDTO.SearchResultDTO searchUserMembershipBrands(
@@ -103,44 +105,46 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
         UserMembershipBrand umb =
                 userMembershipBrandRepository.findById(userMembershipBrandId)
                         .orElseThrow(() ->
-                                new MembershipException(
-                                        MembershipErrorCode.MEMBERSHIP4001));
+                                new MembershipException(MembershipErrorCode.MEMBERSHIP4001));
 
         if (!umb.getUserId().equals(userId)) {
-            throw new MembershipException(
-                    MembershipErrorCode.MEMBERSHIP4003);
+            throw new MembershipException(MembershipErrorCode.MEMBERSHIP4003);
         }
 
         // 2. 멤버십 브랜드 ID
         Long membershipBrandId = umb.getMembershipBrandId();
-        // 3. 멤버십 → StoreBrand IDs
+
+        // 3. 멤버십 → StoreBrand ID 목록
         List<Long> storeBrandIds =
                 storeBrandMembershipBrandRepository
                         .findStoreBrandIdsByMembershipBrandId(membershipBrandId);
 
         if (storeBrandIds.isEmpty()) {
-            return UserMembershipBrandResponseDTO
-                    .AvailableStoreListDTO.builder()
+            return UserMembershipBrandResponseDTO.AvailableStoreListDTO.builder()
                     .stores(List.of())
                     .build();
         }
 
         // 4. Store 조회
         List<Store> stores =
-                storeRepository
-                        .findStoresByStoreBrandIdsAndKeyword(
-                                storeBrandIds,
-                                keyword
-                        );
+                storeRepository.findStoresByStoreBrandIdsAndKeyword(
+                        storeBrandIds, keyword
+                );
 
-        // 5. DTO 변환
+        // 5. Google Place 연동 + DTO 변환 (🔥 핵심)
         List<UserMembershipBrandResponseDTO.AvailableStoreDTO> storeDTOs =
                 stores.stream()
-                        .map(userMembershipBrandConverter::toAvailableStoreDTO)
+                        .map(store -> {
+                            var place =
+                                    googleMapSearchClient
+                                            .getPlaceDetail(store.getGoogleId());
+
+                            return userMembershipBrandConverter
+                                    .toAvailableStoreDTO(store, place);
+                        })
                         .toList();
 
-        return UserMembershipBrandResponseDTO
-                .AvailableStoreListDTO.builder()
+        return UserMembershipBrandResponseDTO.AvailableStoreListDTO.builder()
                 .stores(storeDTOs)
                 .build();
     }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -12,6 +12,9 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
 import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+import com.umc.barkit.domain.store.repository.StoreBrandMembershipBrandRepository;
+import com.umc.barkit.domain.store.entity.Store;
+import com.umc.barkit.domain.store.repository.StoreRepository;
 import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -35,6 +38,8 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
     private final UserMembershipBrandRepository userMembershipBrandRepository;
     private final UserMembershipBrandConverter userMembershipBrandConverter;
     private final MembershipBrandRepository membershipBrandRepository;
+    private final StoreBrandMembershipBrandRepository storeBrandMembershipBrandRepository;
+    private final StoreRepository storeRepository;
 
     @Override
     public UserMembershipBrandResponseDTO.SearchResultDTO searchUserMembershipBrands(
@@ -90,5 +95,53 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
         return userMembershipBrandConverter.toBarcodeDTO(umbOpt.get());
     }
 
+    @Override
+    public UserMembershipBrandResponseDTO.AvailableStoreListDTO
+    getAvailableStores(Long userId, Long userMembershipBrandId, String keyword) {
 
+        // 1. 사용자 멤버십 검증
+        UserMembershipBrand umb =
+                userMembershipBrandRepository.findById(userMembershipBrandId)
+                        .orElseThrow(() ->
+                                new MembershipException(
+                                        MembershipErrorCode.MEMBERSHIP4001));
+
+        if (!umb.getUserId().equals(userId)) {
+            throw new MembershipException(
+                    MembershipErrorCode.MEMBERSHIP4003);
+        }
+
+        // 2. 멤버십 브랜드 ID
+        Long membershipBrandId = umb.getMembershipBrandId();
+        // 3. 멤버십 → StoreBrand IDs
+        List<Long> storeBrandIds =
+                storeBrandMembershipBrandRepository
+                        .findStoreBrandIdsByMembershipBrandId(membershipBrandId);
+
+        if (storeBrandIds.isEmpty()) {
+            return UserMembershipBrandResponseDTO
+                    .AvailableStoreListDTO.builder()
+                    .stores(List.of())
+                    .build();
+        }
+
+        // 4. Store 조회
+        List<Store> stores =
+                storeRepository
+                        .findStoresByStoreBrandIdsAndKeyword(
+                                storeBrandIds,
+                                keyword
+                        );
+
+        // 5. DTO 변환
+        List<UserMembershipBrandResponseDTO.AvailableStoreDTO> storeDTOs =
+                stores.stream()
+                        .map(userMembershipBrandConverter::toAvailableStoreDTO)
+                        .toList();
+
+        return UserMembershipBrandResponseDTO
+                .AvailableStoreListDTO.builder()
+                .stores(storeDTOs)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandRepository.java
@@ -3,6 +3,7 @@ package com.umc.barkit.domain.store.repository;
 import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.domain.store.enums.Category;
 import com.umc.barkit.domain.store.repository.projection.BrandIdNameProjection;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -48,4 +49,26 @@ public interface StoreBrandRepository extends JpaRepository<StoreBrand,Long> {
 //            "order by length(sb.name) desc"
         )
     Optional<StoreBrand> findMatchedBrand(String query);
+
+    @Query("""
+    select sb
+    from StoreBrand sb
+    where sb.id in :storeBrandIds
+      and exists (
+          select 1
+          from Store s
+          where s.brand = sb
+            and (:cursor is null or sb.id > :cursor)
+      )
+      and (:keyword is null
+           or lower(sb.name) like lower(concat('%', :keyword, '%')))
+    order by sb.id asc
+    """)
+    List<StoreBrand> findAvailableStoreBrands(
+            @Param("storeBrandIds") List<Long> storeBrandIds,
+            @Param("keyword") String keyword,
+            @Param("cursor") Long cursor,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreRepository.java
@@ -22,4 +22,18 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
             "where s.googleId in :googleIds"
         )
     List<ViewCountProjection> findViewCountsByGoogleIds(@Param("googleIds") Collection<String> googleIds);
+
+    //  멤버십 기준 매장 조회 (검색 optional)
+    @Query("""
+        select distinct s
+        from Store s
+        join s.brand sb
+        where sb.id in :storeBrandIds
+          and (:keyword is null
+               or lower(sb.name) like lower(concat('%', :keyword, '%')))
+    """)
+    List<Store> findStoresByStoreBrandIdsAndKeyword(
+            @Param("storeBrandIds") List<Long> storeBrandIds,
+            @Param("keyword") String keyword
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreRepository.java
@@ -25,15 +25,20 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
 
     //  멤버십 기준 매장 조회 (검색 optional)
     @Query("""
-        select distinct s
-        from Store s
-        join s.brand sb
-        where sb.id in :storeBrandIds
-          and (:keyword is null
-               or lower(sb.name) like lower(concat('%', :keyword, '%')))
+    select distinct s
+    from Store s
+    join s.brand sb
+    where sb.id in :storeBrandIds
+      and (:keyword is null
+           or lower(sb.name) like lower(concat('%', :keyword, '%')))
+      and (:cursor is null or s.id > :cursor)
+    order by s.id asc
     """)
     List<Store> findStoresByStoreBrandIdsAndKeyword(
             @Param("storeBrandIds") List<Long> storeBrandIds,
-            @Param("keyword") String keyword
+            @Param("keyword") String keyword,
+            @Param("cursor") Long cursor,
+            org.springframework.data.domain.Pageable pageable
     );
+
 }

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreRepository.java
@@ -2,6 +2,7 @@ package com.umc.barkit.domain.store.repository;
 
 import com.umc.barkit.domain.store.entity.Store;
 import com.umc.barkit.domain.store.repository.projection.ViewCountProjection;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,20 +26,14 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
 
     //  멤버십 기준 매장 조회 (검색 optional)
     @Query("""
-    select distinct s
+    select s.id
     from Store s
-    join s.brand sb
-    where sb.id in :storeBrandIds
-      and (:keyword is null
-           or lower(sb.name) like lower(concat('%', :keyword, '%')))
-      and (:cursor is null or s.id > :cursor)
+    where s.brand.id = :brandId
     order by s.id asc
-    """)
-    List<Store> findStoresByStoreBrandIdsAndKeyword(
-            @Param("storeBrandIds") List<Long> storeBrandIds,
-            @Param("keyword") String keyword,
-            @Param("cursor") Long cursor,
-            org.springframework.data.domain.Pageable pageable
+""")
+    List<Long> findStoreIdsByBrandId(
+            @Param("brandId") Long brandId,
+            Pageable pageable
     );
 
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 로그인한 사용자가 보유한 특정 멤버십으로 적립/할인 가능한 매장 목록을 조회합니다.
- 멤버십 브랜드 기준 필터링
- 매장명 검색(keyword) 지원
- cursor + size 기반 페이징 적용
- UI 요구사항에 맞춰 브랜드 단위 정보만 반환하도록 DTO 정리
closes #75 

## 🛠️ 작업 상세 내용
- [x] 멤버십 브랜드 기준 적립/할인 가능 매장 조회 API 구현 
- [x] keyword 기반 매장(브랜드) 검색 로직 적용
- [x] cursor + size 기반 페이징 처리
- [x] UI 요구사항에 맞게 매장명(ex 스타벅스 홍대점) 제거

## 📸 스크린샷 (선택)  
sql 1. 유저가 해당 멤버십을 보유했는지
<img width="965" height="620" alt="image" src="https://github.com/user-attachments/assets/c95859bf-a550-49ee-a55d-61f4b4f6cda7" />
  
sql 2.  멤버십 ↔ 적립 가능 브랜드 매핑
<img width="1204" height="776" alt="image" src="https://github.com/user-attachments/assets/631445bb-b7bc-425f-9272-2187cb853ad2" />
실제 지점이 존재 하지 않고 브랜드만 존재할 경우를 고려하여 테스트 브랜드 삽

sql 3. 실제 지점이 존재하는 브랜드만 추림(store에 있는)
<img width="1086" height="788" alt="image" src="https://github.com/user-attachments/assets/d34ea0d3-a70d-4ff5-ac63-0f7e811ca1c7" />
테스트 브랜드 나오지 않음


1.  기본 조회 (userMembershipBrandId = 15, keyword = (없음), cursor = (없음), size = (없음), 기본 20개)
<img width="2350" height="828" alt="image" src="https://github.com/user-attachments/assets/374bba2a-713c-4523-9f58-93a48ee09969" />
  

2. size 지정 조회 (userMembershipBrandId = 15, keyword = 메가커피 or (없음) , cursor = (없음), size =)    
1 )키워드 없음  (userMembershipBrandId = 15, keyword = (없음) , cursor = (없음), size = 5)    
<img width="2559" height="1301" alt="image" src="https://github.com/user-attachments/assets/b7ad479f-f8dc-46d5-8562-274260be73a4" />
2) 키워드 메가 커피  (userMembershipBrandId = 15, keyword = 메가커피  , cursor = (없음), size = (없음)) 
<img width="1887" height="1781" alt="image" src="https://github.com/user-attachments/assets/927d2c01-0cd7-48ca-ba9b-9652d761dfb7" />
  
4. cursor 기반 다음 페이지 조회
1단계: size = 3 
<img width="2636" height="1922" alt="image" src="https://github.com/user-attachments/assets/046f3d2f-b24a-4cf5-8999-07c26ce503c0" />
2단계: size = 3 , cursor: 67
<img width="2616" height="1947" alt="image" src="https://github.com/user-attachments/assets/9f362eb9-4c25-4a6f-8a76-bd4c5b42ffc8" />

5. 존재 하지 않는 이름 검색 (keyword: 가위바위)
<img width="2786" height="1721" alt="image" src="https://github.com/user-attachments/assets/ee1c292d-3419-47ac-a432-345fc8c025e6" />
빈 배열 반환

## 💬 기타(공유사항 to 리뷰어)
- 초기에는 매장 지점(store) 단위 + Google Places 연동까지 고려했으나, 현재 Figma UI 상에서는 브랜드 단위 리스트만 노출되는 구조임을 확인하여 1단계 구현 범위에 맞게 DTO를 단순화했습니다.
- 위치 기반(lat/lng), 거리순 정렬, Google Places 연동은 다음 단계 확장 포인트로 분리했습니다.