### PR TITLE
✨ [Feat] 특정 멤버십 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -20,9 +20,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-
-
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/user-membership-brands")
@@ -131,5 +128,29 @@ public class UserMembershipBrandController {
         return ResponseEntity
                 .status(successCode.getStatus())
                 .body(ApiResponse.onSuccess(successCode, null));
+    }
+
+    @Operation(
+            summary = "사용자 보유 특정 멤버십 상세 정보 조회",
+            description = "사용자가 등록한 특정 멤버십의 상세 정보와 적립/할인 가능한 매장 목록을 조회합니다."
+    )
+    @GetMapping("/{userMembershipBrandId}/detail")
+    public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.MembershipDetailDTO>> getMembershipDetail(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long userMembershipBrandId
+    ) {
+        // JWT 인증 체크
+        if (userDetails == null) {
+            throw new GeneralException(GeneralErrorCode.UNAUTHORIZED);
+        }
+
+        Long userId = userDetails.getUserId();
+
+        UserMembershipBrandResponseDTO.MembershipDetailDTO result =
+                userMembershipBrandQueryService.getMembershipDetail(userId, userMembershipBrandId);
+
+        return ResponseEntity
+                .status(GeneralSuccessCode.OK.getStatus())
+                .body(ApiResponse.onSuccess(GeneralSuccessCode.OK, result));
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -8,6 +8,7 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.exception.MembershipException;
 import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
+import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
 import com.umc.barkit.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -86,11 +87,27 @@ public class UserMembershipBrandConverter {
                 .brandName(brand.getName())
                 .build();
     }
+
+    public UserMembershipBrandResponseDTO.MembershipDetailDTO toMembershipDetailDTO(
+            UserMembershipBrand userMembershipBrand,
+            MembershipBrand membershipBrand,
+            List<StoreBrand> storeBrands
+    ) {
+        List<UserMembershipBrandResponseDTO.StoreBrandDTO> storeBrandDTOs = storeBrands.stream()
+                .map(store -> UserMembershipBrandResponseDTO.StoreBrandDTO.builder()
+                        .storeBrandId(store.getId())
+                        .name(store.getName())
+                        .logoUrl(store.getLogoUrl())
+                        .build())
+                .collect(Collectors.toList());
+
+        return UserMembershipBrandResponseDTO.MembershipDetailDTO.builder()
+                .userMembershipBrandId(userMembershipBrand.getId())
+                .membershipBrandName(membershipBrand.getName())
+                .themeColor(membershipBrand.getColor())
+                .logoUrl(membershipBrand.getLogoUrl())
+                .membershipNumber(userMembershipBrand.getMembershipNumber())
+                .storeBrands(storeBrandDTOs)
+                .build();
+    }
 }
-
-
-
-
-
-
-

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -37,6 +37,7 @@ public class UserMembershipBrandResponseDTO {
         private Long userMembershipBrandId;
         private String membershipNumber;
     }
+
     @Getter
     @Builder
     @AllArgsConstructor
@@ -44,5 +45,28 @@ public class UserMembershipBrandResponseDTO {
         private String membershipNumber;
         private String logoUrl;
         private String brandName;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MembershipDetailDTO {
+        private Long userMembershipBrandId;
+        private String membershipBrandName;
+        private String themeColor;
+        private String logoUrl;
+        private String membershipNumber;
+        private List<StoreBrandDTO> storeBrands;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StoreBrandDTO {
+        private Long storeBrandId;
+        private String name;
+        private String logoUrl;
     }
 }

--- a/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/membership/exception/code/MembershipErrorCode.java
@@ -18,6 +18,7 @@ public enum MembershipErrorCode implements BaseErrorCode {
     MEMBERSHIP4002(HttpStatus.BAD_REQUEST, "MEMBERSHIP4002", "멤버십 번호는 최대 20자까지 입력 가능합니다."),
     MEMBERSHIP4003(HttpStatus.BAD_REQUEST, "MEMBERSHIP4003", "멤버십 번호는 숫자만 입력 가능합니다."),
     MEMBERSHIP4004(HttpStatus.NOT_FOUND,"MEMBERSHIP4004","등록된 사용자 멤버십이 존재하지 않습니다."),
+    MEMBERSHIP4005(HttpStatus.FORBIDDEN, "MEMBERSHIP4005", "본인의 멤버십만 조회할 수 있습니다."),  // 추가
     MEMBERSHIP4006(HttpStatus.FORBIDDEN, "MEMBERSHIP4006", "본인의 멤버십만 대표 멤버십으로 설정할 수 있습니다."),
     MEMBERSHIP4007(HttpStatus.BAD_REQUEST, "MEMBERSHIP4007", "대표 멤버십은 최대 3개까지 설정할 수 있습니다."),
     // ========== 바코드 에러 (BARCODE) ==========

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.umc.barkit.domain.membership.repository;
 
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.store.entity.StoreBrand;
 
 import java.util.List;
 
@@ -19,4 +20,7 @@ public interface UserMembershipBrandRepositoryCustom {
 
     // 대표 멤버십 개수 조회
     int countMainByUserId(Long userId);
+
+    // 멤버십 브랜드에 연관된 StoreBrand 목록 조회
+    List<StoreBrand> findStoreBrandsByMembershipBrandId(Long membershipBrandId);
 }

--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
+import com.umc.barkit.domain.store.entity.StoreBrand;
 import lombok.RequiredArgsConstructor;
 
 import java.util.HashMap;
@@ -12,6 +13,8 @@ import java.util.Map;
 
 import static com.umc.barkit.domain.membership.entity.QMembershipBrand.membershipBrand;
 import static com.umc.barkit.domain.membership.entity.QUserMembershipBrand.userMembershipBrand;
+import static com.umc.barkit.domain.store.entity.QStoreBrand.storeBrand;
+import static com.umc.barkit.domain.store.entity.mapping.QStoreBrandMembershipBrand.storeBrandMembershipBrand;
 
 @RequiredArgsConstructor
 public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRepositoryCustom {
@@ -98,4 +101,16 @@ public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRep
 
         return count == null ? 0 : count.intValue();
     }
+
+    @Override
+    public List<StoreBrand> findStoreBrandsByMembershipBrandId(Long membershipBrandId) {
+        return queryFactory
+                .selectFrom(storeBrand)
+                .join(storeBrandMembershipBrand)
+                .on(storeBrandMembershipBrand.storeBrand.eq(storeBrand))
+                .where(storeBrandMembershipBrand.membershipBrand.id.eq(membershipBrandId))
+                .orderBy(storeBrand.id.asc())
+                .fetch();
+    }
+
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryService.java
@@ -14,4 +14,9 @@ public interface UserMembershipBrandQueryService {
 
     UserMembershipBrandResponseDTO.UserMembershipBarcodeDTO getUserMembershipBarcode(Long userId,Long membershipBrandId);
 
+    // 사용자 보유 특정 멤버십 상세 정보 조회
+    UserMembershipBrandResponseDTO.MembershipDetailDTO getMembershipDetail(
+            Long userId,
+            Long userMembershipBrandId
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -12,6 +12,7 @@ import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.exception.code.MembershipErrorCode;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
 import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+import com.umc.barkit.domain.store.entity.StoreBrand;
 import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
 
 import lombok.RequiredArgsConstructor;
@@ -90,5 +91,35 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
         return userMembershipBrandConverter.toBarcodeDTO(umbOpt.get());
     }
 
+    @Override
+    public UserMembershipBrandResponseDTO.MembershipDetailDTO getMembershipDetail(
+            Long userId,
+            Long userMembershipBrandId
+    ) {
+        // 1. UserMembershipBrand 조회
+        UserMembershipBrand userMembershipBrand = userMembershipBrandRepository
+                .findById(userMembershipBrandId)
+                .orElseThrow(() -> new MembershipException(MembershipErrorCode.MEMBERSHIP4004));
 
+        // 2. 본인 소유 확인
+        if (!userMembershipBrand.getUserId().equals(userId)) {
+            throw new MembershipException(MembershipErrorCode.MEMBERSHIP4005);
+        }
+
+        // 3. MembershipBrand 조회
+        MembershipBrand membershipBrand = membershipBrandRepository
+                .findById(userMembershipBrand.getMembershipBrandId())
+                .orElseThrow(() -> new MembershipException(MembershipErrorCode.BRAND4001));
+
+        // 4. 적립/할인 가능한 StoreBrand 목록 조회
+        List<StoreBrand> storeBrands = userMembershipBrandRepository
+                .findStoreBrandsByMembershipBrandId(userMembershipBrand.getMembershipBrandId());
+
+        // 5. DTO 변환 및 반환
+        return userMembershipBrandConverter.toMembershipDetailDTO(
+                userMembershipBrand,
+                membershipBrand,
+                storeBrands
+        );
+    }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 사용자가 등록한 특정 멤버십의 상세 정보와 해당 멤버십으로 적립/할인 가능한 매장 목록을 조회하는 API 구현
> GET /api/user-membership-brands/{userMembershipBrandId}/deta

## 🛠️ 작업 상세 내용
- [x] MembershipDetailDTO, StoreBrandDTO Response DTO 추가
- [x] toMembershipDetailDTO Converter 메서드 추가
- [x] findStoreBrandsByMembershipBrandId Repository 메서드 추가 (QueryDSL)
- [x] getMembershipDetail Service 메서드 추가
- [x] 본인 소유 멤버십 검증 로직 구현
- [x] MEMBERSHIP4004 (등록된 멤버십 없음), MEMBERSHIP4005 (타인 멤버십 조회) 에러 처리
- [x] JWT 인증 적용

## 📸 스크린샷 (선택)
- 조회 성공
<img width="685" height="300" alt="스크린샷 2026-02-05 오전 9 18 47" src="https://github.com/user-attachments/assets/2704301b-6e6a-494b-b25f-bd674b422712" />

- 본인 소유 멤버십 검증 실패
<img width="693" height="119" alt="스크린샷 2026-02-05 오전 9 10 49" src="https://github.com/user-attachments/assets/60dcf937-908b-412d-a22d-ad263aa8007d" />

- 멤버십 존재 검증 실패
<img width="690" height="115" alt="스크린샷 2026-02-05 오전 9 11 08" src="https://github.com/user-attachments/assets/814f9f40-8bb5-4278-b410-7946ff92f318" />


## 💬 기타(공유사항 to 리뷰어)