### PR TITLE
[Feat] 마이페이지 알림/위치 권한 설정 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -99,5 +99,48 @@ public class UserController implements UserControllerDocs{
         return ApiResponse.onSuccess(UserSuccessCode.LOGOUT_OK, null);
     }
 
+    // 알림 설정 변경
+    @PatchMapping("/users/me/notification")
+    public ApiResponse<Void> updateNotification(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UserRequestDto.UpdateNotificationRequestDto request
+    ) {
+        userCommandService.updateNotification(
+                userDetails.getUserId(),
+                request.enabled()
+        );
+
+        String message = request.enabled()
+                ? "알림이 활성화되었습니다."
+                : "알림이 비활성화되었습니다.";
+
+        return ApiResponse.onSuccess(
+                UserSuccessCode.NOTIFICATION_UPDATED,
+                null,
+                message
+        );
+    }
+
+    // 위치 권한 동의 변경
+    @PatchMapping("/users/me/location-consent")
+    public ApiResponse<Void> updateLocationConsent(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody @Valid UserRequestDto.UpdateLocationConsentRequestDto request
+    ) {
+        userCommandService.updateLocationConsent(
+                userDetails.getUserId(),
+                request.consented()
+        );
+
+        String message = request.consented()
+                ? "위치 권한 요청이 허용되었습니다."
+                : "위치 권한 요청이 거부되었습니다.";
+
+        return ApiResponse.onSuccess(
+                UserSuccessCode.LOCATION_CONSENT_UPDATED,
+                null,
+                message
+        );
+    }
 
 }

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -113,4 +113,35 @@ public interface UserControllerDocs {
     ApiResponse<Void> logout(
             @RequestBody @Valid UserRequestDto.RefreshRequestDto request
     );
+
+    @Operation(
+            summary = "알림 수신 설정 변경 API",
+            description = "마이페이지에서 사용자의 알림 수신 여부를 변경합니다.<br>" +
+                    "JWT 인증 방식으로 동작하며, 로그인한 사용자 본인의 설정만 변경할 수 있습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "알림 설정 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자가 존재하지 않음")
+    })
+    ApiResponse<Void> updateNotification(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserRequestDto.UpdateNotificationRequestDto request
+    );
+
+    @Operation(
+            summary = "위치 권한 동의 상태 변경 API",
+            description = "마이페이지에서 사용자의 위치 정보 제공 동의 여부를 변경합니다.<br>" +
+                    "해당 설정은 위치 기반 서비스 제공 여부 판단에 사용됩니다.<br>" +
+                    "JWT 인증 방식으로 동작하며, 로그인한 사용자 본인의 설정만 변경할 수 있습니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "위치 권한 동의 상태 변경 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "사용자가 존재하지 않음")
+    })
+    ApiResponse<Void> updateLocationConsent(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserRequestDto.UpdateLocationConsentRequestDto request
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -76,4 +76,14 @@ public class UserRequestDto {
             @NotBlank
             String refreshToken
     ) {}
+
+    // 알림 설정 변경
+    public record UpdateNotificationRequestDto(
+            Boolean enabled
+    ) {}
+
+    // 위치 권한 동의 변경
+    public record UpdateLocationConsentRequestDto(
+            Boolean consented
+    ) {}
 }

--- a/src/main/java/com/umc/barkit/domain/user/entity/User.java
+++ b/src/main/java/com/umc/barkit/domain/user/entity/User.java
@@ -46,6 +46,14 @@ public class User extends BaseEntity {
     @Column(name = "deleted_at", columnDefinition = "DATETIME(6)")
     private LocalDateTime deletedAt;
 
+    @Builder.Default
+    @Column(name = "notification_enabled", nullable = false)
+    private Boolean notificationEnabled = true;
+
+    @Builder.Default
+    @Column(name = "location_consent", nullable = false)
+    private Boolean locationConsent = false;
+
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
         this.status = UserStatus.INACTIVE;
@@ -60,4 +68,10 @@ public class User extends BaseEntity {
     public void updatePassword(String encodedPassword) {
         this.passwordHash = encodedPassword;
     }
+
+    // 알림 수신 여부 변경
+    public void updateNotificationEnabled(Boolean enabled) { this.notificationEnabled = enabled; }
+
+    // 알림 수신 여부 변경
+    public void updateLocationConsent(Boolean consented) { this.locationConsent = consented; }
 }

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
@@ -17,7 +17,10 @@ public enum UserSuccessCode implements BaseSuccessCode {
 
     PERSONAL_INFO_OK(HttpStatus.OK, "USER2000", "개인정보 조회에 성공했습니다."),
     BIRTH_DATE_UPDATED(HttpStatus.OK, "USER2001", "생년월일 변경에 성공했습니다."),
-    PASSWORD_UPDATED(HttpStatus.OK, "USER2002", "비밀번호 변경에 성공했습니다.");
+    PASSWORD_UPDATED(HttpStatus.OK, "USER2002", "비밀번호 변경에 성공했습니다."),
+
+    NOTIFICATION_UPDATED(HttpStatus.OK, "USER2005", "알림 설정이 변경되었습니다."),
+    LOCATION_CONSENT_UPDATED(HttpStatus.OK, "USER2006", "위치 권한 동의 상태가 변경되었습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
@@ -102,4 +102,22 @@ public class UserCommandService {
         // 비밀번호 업데이트
         user.updatePassword(encodedNewPassword);
     }
+
+    // 알림 설정 변경
+    @Transactional
+    public void updateNotification(Long userId, Boolean enabled) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        user.updateNotificationEnabled(enabled);
+    }
+
+    // 위치 권한 동의 상태 변경
+    @Transactional
+    public void updateLocationConsent(Long userId, Boolean consented) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        user.updateLocationConsent(consented);
+    }
 }

--- a/src/main/java/com/umc/barkit/global/apiPayload/ApiResponse.java
+++ b/src/main/java/com/umc/barkit/global/apiPayload/ApiResponse.java
@@ -44,4 +44,19 @@ public class ApiResponse<T> {
                 result
         );
     }
+
+    // 성공 커스텀 메시지
+    public static <T> ApiResponse<T> onSuccess(
+            BaseSuccessCode successCode,
+            T result,
+            String customMessage
+    ) {
+        return new ApiResponse<>(
+                true,
+                successCode.getCode(),
+                customMessage,
+                result
+        );
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 마이페이지에서 사용자의 알림 설정 및 위치 권한 동의 상태를 토글 방식으로 변경할 수 있는 API를 구현했습니다.
> JWT 인증 기반으로 본인 사용자(users/me) 에 대해서만 설정 변경이 가능합니다.
> 토글 값(true / false)에 따라 응답 메시지가 동적으로 변경되도록 개선했습니다.
close #94 

## 🛠️ 작업 상세 내용
- [x] User 엔티티에 알림 설정 / 위치 권한 동의 컬럼 추가(notification_enabled, location_consent)
- [x] 알림 설정 변경 API 구현(PATCH /api/users/me/notification)
- [x] 위치 권한 동의 상태 변경 API 구현(PATCH /api/users/me/location-consent)
- [x] 토글 값에 따라 응답 메시지 분기 처리

## 📸 스크린샷 (선택)
1. 알림 설정 변경 API
<img width="1014" height="825" alt="image" src="https://github.com/user-attachments/assets/eb7a362d-4218-4f99-9f3e-93289192a1de" />
<img width="816" height="860" alt="image" src="https://github.com/user-attachments/assets/7686b802-a030-4a38-b5f5-b448c4f54ea2" />

2. 위치 권한 동의 상태 변경 API
<img width="921" height="862" alt="image" src="https://github.com/user-attachments/assets/cfb9d341-0828-46b4-885e-38e97e4ffe45" />
<img width="918" height="865" alt="image" src="https://github.com/user-attachments/assets/3dc589fd-18d8-4641-ac2b-bae9f67fc074" />



## 💬 기타(공유사항 to 리뷰어)
- 알림/위치 설정은 실제 푸시 발송이나 위치 수집이 아닌, 사용자 설정 상태 저장용 API입니다.
- JPA Dirty Checking을 사용하여 save() 호출 없이 상태 변경을 반영합니다.