### PR TITLE
[Feat] 홈 대시보드 대표 멤버십 분리 및 바코드 정보 추가

### DIFF
--- a/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
+++ b/src/main/java/com/umc/barkit/domain/home/dto/response/HomeDashboardResponse.java
@@ -9,12 +9,12 @@ import java.util.List;
 
 /**
  * 홈 대시보드 전용 응답 DTO
- * - 홈 화면 전용
- * - 멤버십 카드 리스트 제공
- * - 매장 즐겨찾기 기능 제거됨 (기획 변경)
  */
 public class HomeDashboardResponse {
 
+    /**
+     * 홈 대시보드 응답
+     */
     @Getter
     @Builder
     @NoArgsConstructor
@@ -22,36 +22,48 @@ public class HomeDashboardResponse {
     public static class DashboardDTO {
 
         /**
-         * 사용자 보유 멤버십 카드 요약
+         * 대표 멤버십 카드 (isMain = true)
+         */
+        private List<MainMembershipDTO> mainMemberships;
+
+        /**
+         * 전체 멤버십 카드 (대표 멤버십 포함)
          */
         private List<MembershipSummaryDTO> memberships;
     }
 
+    /**
+     * 대표 멤버십 DTO (바코드 렌더링용 membershipNumber 포함)
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MainMembershipDTO {
+
+        private Long userMembershipBrandId;
+        private Long membershipBrandId;
+        private String name;
+        private String logoUrl;
+
+        /**
+         * 바코드 raw value (= membershipNumber)
+         */
+        private String membershipNumber;
+    }
+
+    /**
+     * 일반 멤버십 DTO (바코드 없음)
+     */
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MembershipSummaryDTO {
 
-        /**
-         * 유저 멤버십 ID
-         * - 대표 멤버십 설정 / 상세 조회 등에 사용
-         */
-        private Long userMembershipBrandId; // 추가됨
-
-        /**
-         * 멤버십 브랜드 ID
-         */
+        private Long userMembershipBrandId;
         private Long membershipBrandId;
-
-        /**
-         * 멤버십 브랜드 이름
-         */
         private String name;
-
-        /**
-         * 멤버십 브랜드 로고 URL
-         */
         private String logoUrl;
     }
 }

--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
@@ -25,33 +25,10 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
     @Override
     public HomeDashboardResponse.DashboardDTO getDashboard(Long userId) {
 
-        /**
-         * 사용자 보유 멤버십 정렬 규칙
-         *
-         * 1. 대표 멤버십(isMain = true) 우선 노출
-         * 2. 동일 조건 내에서는 등록순(createdAt ASC)
-         *
-         * → 홈 화면에서 대표 멤버십을 가장 먼저 보여주기 위한 UX 정책
-         */
         List<UserMembershipBrand> userMemberships =
-                userMembershipBrandRepository.findByUserId(userId)
-                        .stream()
-                        .sorted(
-                                Comparator
-                                        .comparing(
-                                                UserMembershipBrand::getIsMain,
-                                                Comparator.nullsLast(Boolean::compareTo)
-                                        ).reversed()
-                                        .thenComparing(
-                                                UserMembershipBrand::getCreatedAt,
-                                                Comparator.nullsLast(Comparator.naturalOrder())
-                                        )
-                        )
-                        .toList();
+                userMembershipBrandRepository.findByUserId(userId);
 
-        /**
-         * MembershipBrand 조회 (ID → Entity 매핑)
-         */
+        // MembershipBrand 매핑
         Map<Long, MembershipBrand> membershipBrandMap =
                 membershipBrandRepository.findAllById(
                                 userMemberships.stream()
@@ -64,17 +41,41 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                                 brand -> brand
                         ));
 
-        /**
-         * DTO 변환
-         */
-        List<HomeDashboardResponse.MembershipSummaryDTO> membershipDTOs =
+        // 1. 대표 멤버십 (isMain = true)
+        List<HomeDashboardResponse.MainMembershipDTO> mainMemberships =
                 userMemberships.stream()
-                        .map(userMembership -> {
+                        .filter(UserMembershipBrand::getIsMain)
+                        .sorted(Comparator.comparing(
+                                UserMembershipBrand::getCreatedAt,
+                                Comparator.nullsLast(Comparator.naturalOrder())
+                        ))
+                        .map(umb -> {
                             MembershipBrand brand =
-                                    membershipBrandMap.get(userMembership.getMembershipBrandId());
+                                    membershipBrandMap.get(umb.getMembershipBrandId());
+
+                            return HomeDashboardResponse.MainMembershipDTO.builder()
+                                    .userMembershipBrandId(umb.getId())
+                                    .membershipBrandId(brand.getId())
+                                    .name(brand.getName())
+                                    .logoUrl(brand.getLogoUrl())
+                                    .membershipNumber(umb.getMembershipNumber()) // 바코드용
+                                    .build();
+                        })
+                        .toList();
+
+        // 2. 전체 멤버십 (대표 멤버십 포함)
+        List<HomeDashboardResponse.MembershipSummaryDTO> memberships =
+                userMemberships.stream()
+                        .sorted(Comparator.comparing(
+                                UserMembershipBrand::getCreatedAt,
+                                Comparator.nullsLast(Comparator.naturalOrder())
+                        ))
+                        .map(umb -> {
+                            MembershipBrand brand =
+                                    membershipBrandMap.get(umb.getMembershipBrandId());
 
                             return HomeDashboardResponse.MembershipSummaryDTO.builder()
-                                    .userMembershipBrandId(userMembership.getId()) // 추가됨
+                                    .userMembershipBrandId(umb.getId())
                                     .membershipBrandId(brand.getId())
                                     .name(brand.getName())
                                     .logoUrl(brand.getLogoUrl())
@@ -83,7 +84,8 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                         .toList();
 
         return HomeDashboardResponse.DashboardDTO.builder()
-                .memberships(membershipDTOs)
+                .mainMemberships(mainMemberships)
+                .memberships(memberships)
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
홈 대시보드에서 로그인 사용자의 멤버십 정보를 조회하는 API를 구현했습니다.  
기존 기능에서 대표 멤버십과 일반 멤버십을 구분하여 반환하도록 수정했습니다.

## 🛠️ 작업 상세 내용
- [x] 대표 멤버십(Main Membership) / 일반 멤버십 분리 조회 로직 구현
- [x] 대표 멤버십은 바코드, 멤버십 번호 포함 DTO로 반환
- [x] 멤버십 리스트에는 전체 멤버십(대표 포함) 반환하도록 응답 구조 수정
- [x] 생성일 기준 정렬 적용 (등록 순 유지)

## 📸 스크린샷 (선택)
<img width="1162" height="322" alt="image" src="https://github.com/user-attachments/assets/1cc5bf6d-7e19-4069-8bbc-a39482b86dd2" />

대표 멤버십
<img width="1771" height="1284" alt="image" src="https://github.com/user-attachments/assets/9a42fcc2-b668-4d63-95ac-9c4f3c7391db" />   
일반 멤버십  + 대표 멤버십
<img width="1221" height="754" alt="image" src="https://github.com/user-attachments/assets/f21050a5-f4b2-4884-b4b8-0c699b043519" />
지난번 로직과 마찬가지로 생성 순 정렬

## 💬 기타(공유사항 to 리뷰어)
- 기획에 맞춰 멤버십 리스트(`memberships`)에는 대표 멤버십도 포함되도록 설계했습니다.