### PR TITLE
✨ [Feat] 카카오 소셜 로그인 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/controller/OAuthCallbackController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/OAuthCallbackController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  * (테스트 전용) 카카오 로그인 Redirect URI로 들어오는 콜백을 받아,
  * code(인가 코드)를 이용해 실제 로그인 로직을 실행해보기 위한 컨트롤러
  */
-public class OAuthCallbackController {
+public class OAuthCallbackController implements OAuthCallbackControllerDocs{
 
     private final UserQueryService userQueryService;
 

--- a/src/main/java/com/umc/barkit/domain/user/controller/OAuthCallbackController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/OAuthCallbackController.java
@@ -1,0 +1,30 @@
+package com.umc.barkit.domain.user.controller;
+
+import com.umc.barkit.domain.user.dto.req.UserRequestDto;
+import com.umc.barkit.domain.user.dto.res.UserResponseDto;
+import com.umc.barkit.domain.user.dto.res.UserResponseDto.LoginResponseDto;
+import com.umc.barkit.domain.user.exception.code.UserSuccessCode;
+import com.umc.barkit.domain.user.service.query.UserQueryService;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+/**
+ * (테스트 전용) 카카오 로그인 Redirect URI로 들어오는 콜백을 받아,
+ * code(인가 코드)를 이용해 실제 로그인 로직을 실행해보기 위한 컨트롤러
+ */
+public class OAuthCallbackController {
+
+    private final UserQueryService userQueryService;
+
+    // 프론트 연동 전에 "백엔드만"으로도 카카오 로그인 흐름이 정상 동작하는지 확인
+    @GetMapping("/oauth/kakao/callback")
+    public ApiResponse<LoginResponseDto> kakaoCallback(@RequestParam String code) {
+        var dto = new UserRequestDto.KakaoLoginRequestDto(code, "http://localhost:8080/oauth/kakao/callback");
+        return ApiResponse.onSuccess(UserSuccessCode.LOGIN_OK, userQueryService.kakaoLogin(dto));
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/user/controller/OAuthCallbackControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/OAuthCallbackControllerDocs.java
@@ -1,0 +1,24 @@
+package com.umc.barkit.domain.user.controller;
+
+import com.umc.barkit.domain.user.dto.res.UserResponseDto.LoginResponseDto;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import org.springframework.web.bind.annotation.RequestParam;
+
+public interface OAuthCallbackControllerDocs {
+
+    @Operation(
+            summary = "카카오 로그인 콜백 API (백엔드 로컬 테스트용)",
+            description = "카카오 Redirect URI로 들어오는 code(인가 코드)를 받아 로그인 로직을 실행합니다.<br>" +
+                    "로컬에서 백엔드 단독으로 카카오 로그인 흐름을 검증할 때 사용합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공, 서비스 JWT(accessToken/refreshToken) 반환"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "code 누락/형식 오류"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "카카오 인증 실패/토큰 발급 실패")
+    })
+    ApiResponse<LoginResponseDto> kakaoCallback(
+            @RequestParam String code
+    );
+}

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -99,5 +99,13 @@ public class UserController implements UserControllerDocs{
         return ApiResponse.onSuccess(UserSuccessCode.LOGOUT_OK, null);
     }
 
+    // 카카오 로그인 API
+    @PostMapping("/auth/oauth/kakao/login")
+    public ApiResponse<UserResponseDto.LoginResponseDto> kakaoLogin(
+            @RequestBody @Valid UserRequestDto.KakaoLoginRequestDto request
+    ) {
+        return ApiResponse.onSuccess(UserSuccessCode.LOGIN_OK, userQueryService.kakaoLogin(request));
+    }
+
 
 }

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -113,4 +113,7 @@ public interface UserControllerDocs {
     ApiResponse<Void> logout(
             @RequestBody @Valid UserRequestDto.RefreshRequestDto request
     );
+
+
+
 }

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -146,4 +146,18 @@ public interface UserControllerDocs {
             @Valid @RequestBody UserRequestDto.UpdateLocationConsentRequestDto request
     );
 
+    @Operation(
+            summary = "카카오 로그인 API",
+            description = "프론트에서 카카오 인가 코드(code)와 redirectUri를 전달하면,<br>" +
+                    "백엔드가 카카오 토큰 발급/사용자 정보 조회를 수행한 뒤 서비스 JWT(accessToken/refreshToken)를 발급합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공, 서비스 JWT(accessToken/refreshToken) 반환"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "요청 값 검증 실패"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "카카오 인증 실패/토큰 발급 실패")
+    })
+    ApiResponse<UserResponseDto.LoginResponseDto> kakaoLogin(
+            @RequestBody @Valid UserRequestDto.KakaoLoginRequestDto request
+    );
+
 }

--- a/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
@@ -69,4 +69,22 @@ public class UserConverter {
                 user.getBirthDate()
         );
     }
+
+    public static User toSocialUser(
+            String email,
+            String displayName,
+            String passwordHash,
+            Role role
+    ) {
+        return User.builder()
+                .name(displayName)
+                .email(email)
+                .passwordHash(passwordHash)
+                .role(role)
+                .phoneNumber(null)
+                .birthDate(null)
+                .status(UserStatus.ACTIVE)
+                .deletedAt(null)
+                .build();
+    }
 }

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -76,4 +76,10 @@ public class UserRequestDto {
             @NotBlank
             String refreshToken
     ) {}
+
+    // 카카오 로그인
+    public record KakaoLoginRequestDto(
+            @NotBlank String code,
+            @NotBlank String redirectUri
+    ) {}
 }

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
@@ -18,6 +18,10 @@ public enum UserErrorCode implements BaseErrorCode {
     REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH4004", "리프레시 토큰이 유효하지 않습니다."),
     REFRESH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH4005", "리프레시 토큰이 만료되었습니다."),
 
+    // 소셜 로그인
+    INVALID_REDIRECT_URI(HttpStatus.BAD_REQUEST, "AUTH4007", "허용되지 않은 Redirect URI입니다."),
+    OAUTH_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "AUTH4008", "카카오 계정 이메일 제공에 동의가 필요합니다."),
+
     // 비밀번호
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "USER4001", "비밀번호는 8~12자, 영문+특수문자 조합이어야 합니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "USER4002", "비밀번호 확인이 일치하지 않습니다."),

--- a/src/main/java/com/umc/barkit/domain/user/oauth/client/KakaoApiClient.java
+++ b/src/main/java/com/umc/barkit/domain/user/oauth/client/KakaoApiClient.java
@@ -1,0 +1,76 @@
+package com.umc.barkit.domain.user.oauth.client;
+
+import com.umc.barkit.domain.user.oauth.config.KakaoOAuthProperties;
+import com.umc.barkit.domain.user.oauth.dto.KakaoTokenResponseDto;
+import com.umc.barkit.domain.user.oauth.dto.KakaoUserResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+// 카카오 OAuth 서버와 통신하는 코드
+public class KakaoApiClient {
+
+    private final KakaoOAuthProperties props;
+    private final RestTemplate restTemplate;
+
+    public KakaoApiClient(KakaoOAuthProperties props, RestTemplateBuilder builder) {
+        this.props = props;
+        this.restTemplate = builder.build();
+    }
+
+    /**
+     * 인가 코드(code) + redirectUri로 카카오 토큰 발급 API 호출
+     * POST https://kauth.kakao.com/oauth/token
+     */
+    public KakaoTokenResponseDto exchangeToken(String code, String redirectUri) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", props.restApiKey());
+        body.add("redirect_uri", redirectUri);
+        body.add("code", code);
+
+        if (props.clientSecret() != null && !props.clientSecret().isBlank()) {
+            body.add("client_secret", props.clientSecret());
+        }
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+        ResponseEntity<KakaoTokenResponseDto> response =
+                restTemplate.postForEntity(props.tokenUri(), request, KakaoTokenResponseDto.class);
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new IllegalStateException("Kakao token exchange failed");
+        }
+        return response.getBody();
+    }
+
+    /**
+     * accessToken으로 카카오 유저정보 조회 API 호출
+     * GET https://kapi.kakao.com/v2/user/me
+     */
+    public KakaoUserResponseDto getUserInfo(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(kakaoAccessToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+        ResponseEntity<KakaoUserResponseDto> response =
+                restTemplate.exchange(props.userInfoUri(), HttpMethod.GET, request, KakaoUserResponseDto.class);
+
+        if (!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new IllegalStateException("Kakao user info failed");
+        }
+        return response.getBody();
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/user/oauth/config/KakaoOAuthProperties.java
+++ b/src/main/java/com/umc/barkit/domain/user/oauth/config/KakaoOAuthProperties.java
@@ -1,0 +1,17 @@
+package com.umc.barkit.domain.user.oauth.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao.oauth")
+/**
+ * application.yml의 kakao.oauth.* 설정을 자바 객체로 바인딩
+ */
+public record KakaoOAuthProperties(
+        String restApiKey,
+        String clientSecret,
+        String tokenUri,
+        String userInfoUri,
+        List<String> redirectUriAllowlist
+) {
+}

--- a/src/main/java/com/umc/barkit/domain/user/oauth/config/PropertiesConfig.java
+++ b/src/main/java/com/umc/barkit/domain/user/oauth/config/PropertiesConfig.java
@@ -1,0 +1,11 @@
+package com.umc.barkit.domain.user.oauth.config;
+
+import com.umc.barkit.domain.user.oauth.config.KakaoOAuthProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(KakaoOAuthProperties.class)
+// KakaoOAuthProperties를 스프링 빈으로 등록
+public class PropertiesConfig {
+}

--- a/src/main/java/com/umc/barkit/domain/user/oauth/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/oauth/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,18 @@
+package com.umc.barkit.domain.user.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 카카오 토큰 응답 매핑 DTO
+ * @param accessToken
+ * @param refreshToken
+ */
+public record KakaoTokenResponseDto(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("token_type") String tokenType,
+        @JsonProperty("expires_in") Long expiresIn,
+        @JsonProperty("refresh_token_expires_in") Long refreshTokenExpiresIn,
+        String scope
+) {
+}

--- a/src/main/java/com/umc/barkit/domain/user/oauth/dto/KakaoUserResponseDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/oauth/dto/KakaoUserResponseDto.java
@@ -1,0 +1,23 @@
+package com.umc.barkit.domain.user.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 카카오 유저 정보 응답 매핑 DTO
+ * @param id - 카카오 고유 사용자 식별자
+ * @param kakaoAccount - 이메일
+ * @param properties - 닉네임
+ */
+public record KakaoUserResponseDto(
+        Long id,
+        @JsonProperty("kakao_account") KakaoAccount kakaoAccount,
+        KakaoProperties properties
+) {
+    public record KakaoAccount(
+            @JsonProperty("email") String email
+    ) {}
+
+    public record KakaoProperties(
+            @JsonProperty("nickname") String nickname
+    ) {}
+}

--- a/src/main/java/com/umc/barkit/domain/user/repository/UserOauthRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/UserOauthRepository.java
@@ -1,9 +1,13 @@
 package com.umc.barkit.domain.user.repository;
 
 import com.umc.barkit.domain.user.entity.UserOauth;
+import com.umc.barkit.domain.user.enums.AuthProvider;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface UserOauthRepository extends JpaRepository<UserOauth, Long> {
+
+    Optional<UserOauth> findByProviderAndProviderUidAndDisconnectedAtIsNull(AuthProvider provider, String providerUid);
 }

--- a/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
@@ -5,9 +5,15 @@ import com.umc.barkit.domain.user.dto.req.UserRequestDto;
 import com.umc.barkit.domain.user.dto.res.UserResponseDto;
 import com.umc.barkit.domain.user.dto.res.UserResponseDto.EmailCheckResponseDto;
 import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.entity.UserOauth;
 import com.umc.barkit.domain.user.entity.UserSession;
+import com.umc.barkit.domain.user.enums.AuthProvider;
+import com.umc.barkit.domain.user.enums.Role;
 import com.umc.barkit.domain.user.exception.UserException;
 import com.umc.barkit.domain.user.exception.code.UserErrorCode;
+import com.umc.barkit.domain.user.oauth.client.KakaoApiClient;
+import com.umc.barkit.domain.user.oauth.config.KakaoOAuthProperties;
+import com.umc.barkit.domain.user.repository.UserOauthRepository;
 import com.umc.barkit.domain.user.repository.UserRepository;
 import com.umc.barkit.domain.user.repository.UserSessionRepository;
 import com.umc.barkit.global.auth.details.CustomUserDetails;
@@ -27,6 +33,9 @@ public class UserQueryService {
     private final UserSessionRepository userSessionRepository;
     private final JwtUtil jwtUtil;
     private final PasswordEncoder passwordEncoder;
+    private final KakaoApiClient kakaoApiClient;
+    private final KakaoOAuthProperties kakaoOAuthProperties;
+    private final UserOauthRepository userOauthRepository;
 
     // 아이디 중복 확인
     public UserResponseDto.EmailCheckResponseDto checkEmailAvailability(String email) {
@@ -162,5 +171,86 @@ public class UserQueryService {
                 .orElseThrow(() -> new UserException(UserErrorCode.REFRESH_TOKEN_INVALID));
 
         session.revoke();
+    }
+
+
+    // 카카오 로그인
+    @Transactional
+    public UserResponseDto.LoginResponseDto kakaoLogin(UserRequestDto.KakaoLoginRequestDto dto) {
+        // redirectUri 검증
+        if (kakaoOAuthProperties.redirectUriAllowlist() == null
+                || !kakaoOAuthProperties.redirectUriAllowlist().contains(dto.redirectUri())) {
+            throw new UserException(UserErrorCode.INVALID_REDIRECT_URI);
+        }
+
+        // 인가코드(code)로 카카오 토큰 발급 요청
+        var token = kakaoApiClient.exchangeToken(dto.code(), dto.redirectUri());
+        // 카카오 access_token으로 유저 정보 조회
+        var userInfo = kakaoApiClient.getUserInfo(token.accessToken());
+
+        String providerUid = String.valueOf(userInfo.id()); // 카카오 유저 고유 id(
+        String email = userInfo.kakaoAccount() != null ? userInfo.kakaoAccount().email() : null;
+        String nickname = userInfo.properties() != null ? userInfo.properties().nickname() : null;
+
+        if (email == null || email.isBlank()) {
+            throw new UserException(UserErrorCode.OAUTH_EMAIL_REQUIRED);
+        }
+
+        // (provider, providerUid)로 이미 연결된 유저가 있는지 먼저 확인
+        //  - 있으면 해당 유저로 로그인 처리
+        //  - 없으면 user 생성/조회 후 oauth 연결 저장
+        User user = userOauthRepository
+                .findByProviderAndProviderUidAndDisconnectedAtIsNull(AuthProvider.KAKAO, providerUid)
+                .map(UserOauth::getUser)
+                .orElseGet(() -> upsertUserAndConnectOauth(email, nickname, providerUid));
+
+        // JWT 발급
+        return issueTokens(user);
+    }
+
+    private User upsertUserAndConnectOauth(String email, String nickname, String providerUid) {
+        // 이메일 기반으로 우리 서비스 유저가 이미 있으면 재사용
+        User user = userRepository.findByEmail(email).orElseGet(() -> createSocialUser(email, nickname));
+
+        // user_oauth에 (KAKAO, providerUid) 연결 정보 저장
+        UserOauth oauth = UserOauth.builder()
+                .user(user)
+                .provider(AuthProvider.KAKAO)
+                .providerUid(providerUid)
+                .providerEmail(email)
+                .connectedAt(LocalDateTime.now())
+                .build();
+
+        userOauthRepository.save(oauth);
+        return user;
+    }
+
+    private User createSocialUser(String email, String nickname) {
+        // name에 들어갈 표시 이름 결정 -  nickname을 name으로
+        String displayName = (nickname != null && !nickname.isBlank()) ? nickname : email.split("@")[0];
+        // 랜덤 비번 값
+        String randomPw = java.util.UUID.randomUUID().toString();
+        String encoded = passwordEncoder.encode(randomPw);
+
+        User user = UserConverter.toSocialUser(
+                email,
+                displayName,
+                encoded,
+                Role.ROLE_USER
+        );
+
+        return userRepository.save(user);
+    }
+
+    private UserResponseDto.LoginResponseDto issueTokens(User user) {
+        CustomUserDetails userDetails = new CustomUserDetails(user);
+
+        // access/refresh 발급
+        String accessToken = jwtUtil.createAccessToken(userDetails);
+        String refreshToken = jwtUtil.createRefreshToken(userDetails);
+        saveRefreshToken(user, refreshToken);
+
+        // // 기존 로그인 응답 포맷
+        return UserConverter.toLoginDTO(user, accessToken, refreshToken);
     }
 }

--- a/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
@@ -30,6 +30,8 @@ public class SecurityConfig{
             "/api/auth/signup",
             "/api/auth/check-email",
             "/api/auth/refresh",
+            "/api/auth/oauth/kakao/login",
+            "/oauth/kakao/callback",
             "/api/auth/logout",
             "/swagger-ui/**",
             "/swagger-resources/**",

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -41,3 +41,13 @@ jwt:
     expiration:
       access: 3600000
       refresh: 2592000000
+
+kakao:
+  oauth:
+    rest-api-key: ${KAKAO_REST_API_KEY}
+    client-secret: ${KAKAO_CLIENT_SECRET:}
+    token-uri: https://kauth.kakao.com/oauth/token
+    user-info-uri: https://kapi.kakao.com/v2/user/me
+    redirect-uri-allowlist:
+      - http://localhost:5173/oauth/kakao/callback
+      - http://localhost:8080/oauth/kakao/callback


### PR DESCRIPTION
## #️⃣ 기능 설명
프론트에서 인가코드(code)를 받아 백엔드로 전달하면, 백엔드가 카카오 토큰 발급/사용자 정보 조회를 수행한 뒤 Barkit JWT(access/refresh)를 발급해 반환합니다.

## 🛠️ 작업 상세 내용
- [x] 카카오 OAuth 설정(Properties) 및 allowlist 기반 redirectUri 검증 로직 추가
- [x] 카카오 로그인 API 추가
- [x] 백엔드 단독 테스트용 콜백 엔드포인트 추가: GET /oauth/kakao/callback

## 📸 스크린샷 (선택)
[백엔드 로컬 단독 테스트]
1. 카카오 로그인 성공
<img width="637" height="727" alt="image" src="https://github.com/user-attachments/assets/eabd2dc5-b8ab-4b08-bcf7-a488ece9ddb4" />
<img width="637" height="727" alt="image" src="https://github.com/user-attachments/assets/d6f599a8-9888-4515-b487-f447734250e4" />
<img width="637" height="727" alt="image" src="https://github.com/user-attachments/assets/e3071175-c65a-43e7-b43d-1c1ad460ba51" />
<img width="1415" height="251" alt="image" src="https://github.com/user-attachments/assets/8687afc3-25f5-4b9f-a764-5d6855e13feb" />

2. DB 회원 저장 확인
<img width="1396" height="32" alt="image" src="https://github.com/user-attachments/assets/7523ff5a-e555-472f-8de2-87a415db2dda" />

3. 발급받은 access token으로 개인정보 조회 
<img width="856" height="266" alt="image" src="https://github.com/user-attachments/assets/a9f075ec-86d9-4fe9-945f-dd99ef38e84d" />

## 💬 기타(공유사항 to 리뷰어)
프론트 연동 전 백엔드만으로 카카오 로그인 플로우를 검증하기 위한 테스트용 콜백 엔드포인트를 추가했습니다.
1. 카카오 authorize URL을 브라우저에서 실행 (redirect_uri를 백엔드 콜백으로)
2. 로그인/동의 후 카카오가 아래 형태로 리다이렉트하며 code를 전달(http://localhost:8080/oauth/kakao/callback?code=...)
3. 위 요청이 GET /oauth/kakao/callback로 들어오면 내부적으로 카카오 로그인 로직을 실행하고 JWT를 반환