### PR TITLE
[FEAT] 인기 브랜드 미리보기 API 추가 (조회수 기반)

### DIFF
--- a/src/main/java/com/umc/barkit/domain/home/controller/HomePopularStoreController.java
+++ b/src/main/java/com/umc/barkit/domain/home/controller/HomePopularStoreController.java
@@ -1,0 +1,33 @@
+package com.umc.barkit.domain.home.controller;
+
+import com.umc.barkit.domain.home.dto.response.HomePopularStoreResponse;
+import com.umc.barkit.domain.home.exception.code.HomeSuccessCode;
+import com.umc.barkit.domain.home.service.HomePopularStoreService;
+import com.umc.barkit.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+public class HomePopularStoreController {
+
+    private final HomePopularStoreService homePopularStoreService;
+
+    @Operation(
+            summary = "홈 인기 매장 미리보기 조회",
+            description = "사용자가 보유한 특정 멤버십 기준으로 적립/할인 가능한 매장 중 " +
+                    "조회수(viewCount)가 높은 상위 매장들을 미리보기 형태로 제공합니다. " +
+                    "해당 API는 홈 화면 노출용이며, 최대 5개의 인기 매장을 반환합니다."
+    )
+    @GetMapping("/memberships/{userMembershipBrandId}/popular-stores")
+    public ApiResponse<HomePopularStoreResponse> getPopularStores(
+            @PathVariable Long userMembershipBrandId
+    ) {
+        return ApiResponse.onSuccess(
+                HomeSuccessCode.HOME_POPULAR_STORE_PREVIEW_SUCCESS,
+                homePopularStoreService.getPopularStores(userMembershipBrandId)
+        );
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/home/controller/HomePopularStoreController.java
+++ b/src/main/java/com/umc/barkit/domain/home/controller/HomePopularStoreController.java
@@ -17,17 +17,17 @@ public class HomePopularStoreController {
 
     @Operation(
             summary = "홈 인기 매장 미리보기 조회",
-            description = "사용자가 보유한 특정 멤버십 기준으로 적립/할인 가능한 매장 중 " +
-                    "조회수(viewCount)가 높은 상위 매장들을 미리보기 형태로 제공합니다. " +
-                    "해당 API는 홈 화면 노출용이며, 최대 5개의 인기 매장을 반환합니다."
+            description = "특정 멤버십(MembershipBrand) 기준으로 적립/할인 가능한 매장 브랜드 중 " +
+                    "조회수(viewCount)가 높은 상위 브랜드를 미리보기 형태로 제공합니다. " +
+                    "지점(Store) 단위가 아닌 브랜드(StoreBrand) 단위로 집계하며, 최대 5개를 반환합니다."
     )
-    @GetMapping("/memberships/{userMembershipBrandId}/popular-stores")
+    @GetMapping("/memberships/{membershipBrandId}/popular-stores")
     public ApiResponse<HomePopularStoreResponse> getPopularStores(
-            @PathVariable Long userMembershipBrandId
+            @PathVariable Long membershipBrandId
     ) {
         return ApiResponse.onSuccess(
                 HomeSuccessCode.HOME_POPULAR_STORE_PREVIEW_SUCCESS,
-                homePopularStoreService.getPopularStores(userMembershipBrandId)
+                homePopularStoreService.getPopularStores(membershipBrandId)
         );
     }
 }

--- a/src/main/java/com/umc/barkit/domain/home/dto/response/HomePopularStoreResponse.java
+++ b/src/main/java/com/umc/barkit/domain/home/dto/response/HomePopularStoreResponse.java
@@ -1,0 +1,56 @@
+package com.umc.barkit.domain.home.dto.response;
+
+import com.umc.barkit.domain.store.repository.projection.BrandViewCountProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class HomePopularStoreResponse {
+
+    /**
+     * 인기 브랜드 목록 (최대 5개)
+     */
+    private List<PopularBrand> brands;
+
+    public static HomePopularStoreResponse fromBrands(
+            List<BrandViewCountProjection> brands
+    ) {
+        return new HomePopularStoreResponse(
+                brands.stream()
+                        .map(PopularBrand::from)
+                        .toList()
+        );
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class PopularBrand {
+
+        /**
+         * 매장 브랜드 ID
+         */
+        private Long storeBrandId;
+
+        /**
+         * 매장 브랜드 이름
+         */
+        private String storeBrandName;
+
+        /**
+         * 브랜드 전체 조회수 합계 (선택)
+         * → 프론트에서 필요 없으면 빼도 됨
+         */
+        private Long totalViewCount;
+
+        public static PopularBrand from(BrandViewCountProjection projection) {
+            return new PopularBrand(
+                    projection.getStoreBrandId(),
+                    projection.getStoreBrandName(),
+                    projection.getTotalViewCount()
+            );
+        }
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/home/exception/HomeException.java
+++ b/src/main/java/com/umc/barkit/domain/home/exception/HomeException.java
@@ -1,0 +1,10 @@
+package com.umc.barkit.domain.home.exception;
+
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
+import com.umc.barkit.domain.home.exception.code.HomeErrorCode;
+
+public class HomeException extends GeneralException {
+    public HomeException(HomeErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/home/exception/code/HomeErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/home/exception/code/HomeErrorCode.java
@@ -1,0 +1,32 @@
+package com.umc.barkit.domain.home.exception.code;
+
+import com.umc.barkit.global.apiPayload.code.BaseErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum HomeErrorCode implements BaseErrorCode {
+
+    // ========== 홈 인기 매장 에러 (HOME) ==========
+    HOME4001(
+            HttpStatus.NOT_FOUND,
+            "HOME4001",
+            "존재하지 않는 멤버십입니다."
+    ),
+
+    HOME5001(
+            HttpStatus.INTERNAL_SERVER_ERROR,
+            "HOME5001",
+            "홈 인기 매장 조회 중 오류가 발생했습니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    HomeErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/home/exception/code/HomeSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/home/exception/code/HomeSuccessCode.java
@@ -1,0 +1,30 @@
+package com.umc.barkit.domain.home.exception.code;
+
+import com.umc.barkit.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum HomeSuccessCode implements BaseSuccessCode {
+
+    HOME_POPULAR_STORE_PREVIEW_SUCCESS(
+            HttpStatus.OK,
+            "HOME2001",
+            "홈 인기 매장 미리보기 조회에 성공했습니다."
+    );
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    HomeSuccessCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/home/service/HomePopularStoreService.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomePopularStoreService.java
@@ -1,0 +1,7 @@
+package com.umc.barkit.domain.home.service;
+
+import com.umc.barkit.domain.home.dto.response.HomePopularStoreResponse;
+
+public interface HomePopularStoreService {
+    HomePopularStoreResponse getPopularStores(Long userMembershipBrandId);
+}

--- a/src/main/java/com/umc/barkit/domain/home/service/HomePopularStoreServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomePopularStoreServiceImpl.java
@@ -1,0 +1,50 @@
+package com.umc.barkit.domain.home.service;
+
+import com.umc.barkit.domain.home.dto.response.HomePopularStoreResponse;
+import com.umc.barkit.domain.home.exception.HomeException;
+import com.umc.barkit.domain.home.exception.code.HomeErrorCode;
+import com.umc.barkit.domain.store.entity.Store;
+import com.umc.barkit.domain.store.repository.StoreBrandMembershipBrandRepository;
+import com.umc.barkit.domain.store.repository.StoreRepository;
+import com.umc.barkit.domain.store.repository.projection.BrandViewCountProjection;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomePopularStoreServiceImpl implements HomePopularStoreService {
+
+    private static final int PREVIEW_SIZE = 5;
+
+    private final StoreBrandMembershipBrandRepository storeBrandMembershipBrandRepository;
+    private final StoreRepository storeRepository;
+
+    @Override
+    public HomePopularStoreResponse getPopularStores(Long userMembershipBrandId) {
+
+        // 1️. 멤버십 → StoreBrand IDs
+        List<Long> storeBrandIds =
+                storeBrandMembershipBrandRepository
+                        .findStoreBrandIdsByMembershipBrandId(userMembershipBrandId);
+
+        //  유효하지 않은 멤버십
+        if (storeBrandIds.isEmpty()) {
+            throw new HomeException(HomeErrorCode.HOME4001);
+        }
+
+        // 2. viewCount 기준 인기 매장 상위 5개 조회
+        List<BrandViewCountProjection> brands =
+                storeRepository.findPopularBrandsByBrandIds(
+                        storeBrandIds,
+                        PageRequest.of(0, PREVIEW_SIZE)
+                );
+
+        // 3️. DTO 변환
+        return HomePopularStoreResponse.fromBrands(brands);
+    }
+}

--- a/src/main/java/com/umc/barkit/domain/home/service/HomePopularStoreServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomePopularStoreServiceImpl.java
@@ -25,12 +25,12 @@ public class HomePopularStoreServiceImpl implements HomePopularStoreService {
     private final StoreRepository storeRepository;
 
     @Override
-    public HomePopularStoreResponse getPopularStores(Long userMembershipBrandId) {
+    public HomePopularStoreResponse getPopularStores(Long membershipBrandId) {
 
         // 1️. 멤버십 → StoreBrand IDs
         List<Long> storeBrandIds =
                 storeBrandMembershipBrandRepository
-                        .findStoreBrandIdsByMembershipBrandId(userMembershipBrandId);
+                        .findStoreBrandIdsByMembershipBrandId(membershipBrandId);
 
         //  유효하지 않은 멤버십
         if (storeBrandIds.isEmpty()) {

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreRepository.java
@@ -1,6 +1,7 @@
 package com.umc.barkit.domain.store.repository;
 
 import com.umc.barkit.domain.store.entity.Store;
+import com.umc.barkit.domain.store.repository.projection.BrandViewCountProjection;
 import com.umc.barkit.domain.store.repository.projection.ViewCountProjection;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -36,4 +37,20 @@ public interface StoreRepository extends JpaRepository<Store,Long> {
             Pageable pageable
     );
 
+    // 멤버십 기준 인기 매장 조회
+    @Query("""
+    select
+        sb.id as storeBrandId,
+        sb.name as storeBrandName,
+        sum(s.viewCount) as totalViewCount
+    from Store s
+    join s.brand sb
+    where sb.id in :brandIds
+    group by sb.id, sb.name
+    order by sum(s.viewCount) desc
+""")
+    List<BrandViewCountProjection> findPopularBrandsByBrandIds(
+            @Param("brandIds") List<Long> brandIds,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/umc/barkit/domain/store/repository/projection/BrandViewCountProjection.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/projection/BrandViewCountProjection.java
@@ -1,0 +1,7 @@
+package com.umc.barkit.domain.store.repository.projection;
+
+public interface BrandViewCountProjection {
+    Long getStoreBrandId();
+    String getStoreBrandName();
+    Long getTotalViewCount();
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
>홈 화면에서 사용자가 보유한 특정 멤버십 기준으로 적립/할인 가능한 매장 중 조회수(viewCount)가 높은 인기 브랜드를 미리보기 형태로 제공합니다. 지점(Store) 단위가 아닌 브랜드(StoreBrand) 단위로 집계하여 중복 없이 상위 브랜드를 노출하도록 구현했습니다.
closes #107 
## 🛠️ 작업 상세 내용
- [x] 멤버십 기준 적립/할인 가능 StoreBrand ID 목록 조회
- [x] Store viewCount를 브랜드 단위로 집계(sum) 하여 인기순 정렬
- [x] 홈 화면용 상위 5개 인기 브랜드 미리보기 API 구현
- [x] 예외 처리 추가 (존재하지 않는 멤버십 접근 시)

## 📸 스크린샷 (선택)

1. 정상 조회 케이스(브랜드가 5개 이상일 경우, userMembershipBrandId = 1)

<img width="1356" height="1913" alt="image" src="https://github.com/user-attachments/assets/ff1a8168-19da-49e2-81f4-02d7da35e61a" />



2. 브랜드 개수 5개 미만 케이스 (userMembershipBrandId = 2)
<img width="1293" height="1907" alt="image" src="https://github.com/user-attachments/assets/37360f69-2e77-4a74-8d83-660b5b9b7616" />



3. Swagger – 예외 케이스(존재하지 않는 userMembershipBrandId = 5)

<img width="1624" height="1526" alt="image" src="https://github.com/user-attachments/assets/420a34a5-bb72-4330-b005-f602139ccbb8" />


## 💬 기타(공유사항 to 리뷰어)
- 홈 화면 노출용 API로 지점(Store) 단위가 아닌 브랜드(StoreBrand) 단위로 집계했습니다.
- 브랜드 클릭 시 멤버십 상세 페이지에서 지점 목록을 조회하는 흐름을 고려한 설계입니다.
- GET api/map/store로 viewcount 올리고 swagger 테스트

