### PR TITLE
✨ [Feat] 지도 검색 api에 redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 	implementation 'org.springframework.boot:spring-boot-configuration-processor'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/barkit/BarkitApplication.java
+++ b/src/main/java/com/umc/barkit/BarkitApplication.java
@@ -2,9 +2,11 @@ package com.umc.barkit;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication
 public class BarkitApplication {
 

--- a/src/main/java/com/umc/barkit/domain/store/RedisSmokeTest.java
+++ b/src/main/java/com/umc/barkit/domain/store/RedisSmokeTest.java
@@ -1,0 +1,24 @@
+package com.umc.barkit.domain.store;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RedisSmokeTest implements CommandLineRunner {
+
+    private final StringRedisTemplate stringRedisTemplate;
+
+    @Override
+    public void run(String... args) {
+        String key = "redis:test";
+        stringRedisTemplate.opsForValue().set(key, "hello");
+        String v = stringRedisTemplate.opsForValue().get(key);
+        log.info("Redis smoke test value = {}", v);
+    }
+}
+

--- a/src/main/java/com/umc/barkit/domain/store/RedisSmokeTest.java
+++ b/src/main/java/com/umc/barkit/domain/store/RedisSmokeTest.java
@@ -3,11 +3,13 @@ package com.umc.barkit.domain.store;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
+@Profile({"local", "prod"})
 @Slf4j
 public class RedisSmokeTest implements CommandLineRunner {
 

--- a/src/main/java/com/umc/barkit/domain/store/external/google/service/GoogleSearchCacheService.java
+++ b/src/main/java/com/umc/barkit/domain/store/external/google/service/GoogleSearchCacheService.java
@@ -1,0 +1,39 @@
+package com.umc.barkit.domain.store.external.google.service;
+
+import com.umc.barkit.domain.store.external.google.GoogleMapSearchClient;
+import com.umc.barkit.domain.store.external.google.dto.GoogleResDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleSearchCacheService {
+
+    private final GoogleMapSearchClient googleClient;
+
+    @Cacheable(
+            cacheNames = "googleSearchNear",
+            key = "T(com.umc.barkit.domain.store.external.google.util.CacheKeyUtil).nearKey(#query, #lat, #lng)",
+            unless = "#result == null || #result.isEmpty()"
+    )
+    public List<GoogleResDTO.Place> searchNear(String query, double lat, double lng) {
+        log.info("[CACHE MISS] googleSearchNear query={}", query);
+        return googleClient.searchText(query, lat, lng);
+    }
+
+    @Cacheable(
+            cacheNames = "googleSearchGlobal",
+            key = "T(com.umc.barkit.domain.store.external.google.util.CacheKeyUtil).globalKey(#query)",
+            unless = "#result == null || #result.isEmpty()"
+    )
+    public List<GoogleResDTO.Place> searchGlobal(String query) {
+        log.info("[CACHE MISS] googleSearchGlobal query={}", query);
+        return googleClient.searchText(query);
+    }
+}
+

--- a/src/main/java/com/umc/barkit/domain/store/external/google/util/CacheKeyUtil.java
+++ b/src/main/java/com/umc/barkit/domain/store/external/google/util/CacheKeyUtil.java
@@ -1,0 +1,25 @@
+package com.umc.barkit.domain.store.external.google.util;
+
+import com.umc.barkit.domain.store.util.StoreUtil;
+
+public class CacheKeyUtil {
+    private CacheKeyUtil() {}
+
+    public static String nearKey(String query, double lat, double lng) {
+        String nq = StoreUtil.searchNormalize(query);
+        double lat3 = round(lat, 3);
+        double lng3 = round(lng, 3);
+        return "q=" + nq + ":lat=" + lat3 + ":lng=" + lng3;
+    }
+
+    public static String globalKey(String query) {
+        String nq = StoreUtil.searchNormalize(query);
+        return "q=" + nq;
+    }
+
+    private static double round(double v, int scale) {
+        double p = Math.pow(10, scale);
+        return Math.round(v * p) / p;
+    }
+}
+

--- a/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
@@ -20,6 +20,7 @@ import com.umc.barkit.domain.store.exception.StoreException;
 import com.umc.barkit.domain.store.exception.code.StoreErrorCode;
 import com.umc.barkit.domain.store.external.google.GoogleMapSearchClient;
 import com.umc.barkit.domain.store.external.google.dto.GoogleResDTO;
+import com.umc.barkit.domain.store.external.google.service.GoogleSearchCacheService;
 import com.umc.barkit.domain.store.repository.StoreBrandAliasRepository;
 import com.umc.barkit.domain.store.repository.StoreBrandMembershipBrandRepository;
 import com.umc.barkit.domain.store.repository.StoreBrandRepository;
@@ -58,6 +59,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
 
     private final GoogleMapSearchClient googleClient;
     private final StoreCommandService storeCommandService;
+    private final GoogleSearchCacheService googleSearchCacheService;
 
     @Qualifier("googleSearchExecutor")
     private final Executor googleSearchExecutor;
@@ -349,7 +351,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         Double sendLng = (distanceType == DistanceType.CURRENT) ? userLng : centerLng;
 
         // 검색 반경 5km 필터 적용
-        List<GoogleResDTO.Place> places = googleClient.searchText(query, sendLat, sendLng);
+        List<GoogleResDTO.Place> places = googleSearchCacheService.searchNear(query, sendLat, sendLng);
         if (places == null || places.isEmpty()) return List.of();
 
         List<StoreResDTO.SearchedStoreMembership> membershipsDTO =
@@ -377,7 +379,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
     ) {
         // 위치 없이 호출
         // 검색 반경 5km 필터 미적용
-        List<GoogleResDTO.Place> places = googleClient.searchText(query);
+        List<GoogleResDTO.Place> places = googleSearchCacheService.searchGlobal(query);
         if (places == null || places.isEmpty()) return List.of();
 
         List<StoreResDTO.SearchedStoreMembership> membershipsDTO =
@@ -442,7 +444,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
             Long storeBrandId = filteredBrandIds.get(i);
 
             futures.add(CompletableFuture.supplyAsync(() -> {
-                        List<GoogleResDTO.Place> places = googleClient.searchText(storeName, sendLat, sendLng);
+                        List<GoogleResDTO.Place> places = googleSearchCacheService.searchNear(storeName, sendLat, sendLng);
                         return new GooglePlaceDTO.BrandPlacesResult(storeBrandId, storeName, places);
                     }, googleSearchExecutor)
                     .orTimeout(3, TimeUnit.SECONDS)

--- a/src/main/java/com/umc/barkit/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/RedisCacheConfig.java
@@ -1,0 +1,40 @@
+package com.umc.barkit.global.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory cf) {
+        RedisCacheConfiguration base = RedisCacheConfiguration.defaultCacheConfig()
+                .disableCachingNullValues()
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()
+                        )
+                );
+
+        Map<String, RedisCacheConfiguration> configs = new HashMap<>();
+        configs.put("googleSearchNear", base.entryTtl(Duration.ofMinutes(10)));
+        configs.put("googleSearchGlobal", base.entryTtl(Duration.ofMinutes(30)));
+
+        return RedisCacheManager.builder(cf)
+                .cacheDefaults(base)
+                .withInitialCacheConfigurations(configs)
+                .build();
+    }
+}
+

--- a/src/main/java/com/umc/barkit/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/RedisCacheConfig.java
@@ -1,5 +1,6 @@
 package com.umc.barkit.global.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,7 @@ import java.util.Map;
 
 @Configuration
 @EnableCaching
+@ConditionalOnProperty(name = "spring.data.redis.enabled", havingValue = "true")
 public class RedisCacheConfig {
 
     @Bean

--- a/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
+++ b/src/main/java/com/umc/barkit/global/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig{
             "/api/auth/logout",
             "/swagger-ui/**",
             "/swagger-resources/**",
-            "/v3/api-docs/**",
+            "/v3/api-docs/**"
     };
 
     @Bean

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -4,7 +4,7 @@ spring:
 
   data:
     redis:
-      enabled: false
+      enabled: true
       host: localhost
       port: 6379
 

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -4,7 +4,7 @@ spring:
 
   data:
     redis:
-      enabled: false
+      enabled: true
       host: localhost
       port: 6379
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,11 @@ spring:
   application:
     name: barkit
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: ${AWS_DB_URL}


### PR DESCRIPTION
## #️⃣ 기능 설명
> 지도 검색 api 성능 개선을 위해 redis를 적용합니다.

## 🛠️ 작업 상세 내용
- [x] redis 캐시 적용을 위해 `GoogleSearchCacheService` 클래스 생성
- [x] `RedisCacheConfig` 설정 클래스 생성
- [x] 환경별 설정 분리를 위해 application-local.yml, application-prod.yml 추가

## 📸 스크린샷 (선택)
### 1. kt
<img width="1405" height="347" alt="스크린샷 2026-02-09 오후 3 47 47" src="https://github.com/user-attachments/assets/c268a896-8184-4070-8031-33019d767fc3" />
<img width="1402" height="450" alt="스크린샷 2026-02-09 오후 3 47 56" src="https://github.com/user-attachments/assets/fbaefbf3-f1c9-4a88-8fa7-84edf7ed9fc3" />
<img width="1182" height="32" alt="스크린샷 2026-02-09 오후 3 48 05" src="https://github.com/user-attachments/assets/1cd3b9d1-010b-4460-8463-169b3f85f1a5" />
최초 조회 : 약 9초
<img width="1164" height="30" alt="스크린샷 2026-02-09 오후 3 48 28" src="https://github.com/user-attachments/assets/17711f34-97b5-4012-a1af-a680d466cdaa" />
동일 조건 재검색 : 약 0.7초

### 2. cj
<img width="1410" height="354" alt="스크린샷 2026-02-09 오후 3 48 57" src="https://github.com/user-attachments/assets/b60a846d-2bb4-4b48-9021-7beb0e657891" />
<img width="1399" height="488" alt="스크린샷 2026-02-09 오후 3 49 11" src="https://github.com/user-attachments/assets/7285818e-656b-4eba-83ee-72fe4dcef6e8" />
<img width="1172" height="31" alt="스크린샷 2026-02-09 오후 3 49 19" src="https://github.com/user-attachments/assets/0cf542a6-3992-4630-8d88-ae3e8f088184" />
최초 검색 : 약 3초
<img width="1167" height="44" alt="스크린샷 2026-02-09 오후 3 49 37" src="https://github.com/user-attachments/assets/19887a5c-cbb2-437e-b3a0-c5d83c42756e" />
동일 조건 재 검색 약 0.4초


## 💬 기타(공유사항 to 리뷰어)
- Redis 캐시 적용 테스트를 위해서는 docker에서 redis를 실행 시켜야합니다.
- docker가 없으시다면 설치 후 powershall(윈도우)/터미널(맥)에 아래의 명령어를 입력해주세요
`docker run -d --name redis -p 6379:6379 redis:7`
- 또한 프로필을 분리하여 yml 파일을 생성하였기 때문에 프로필 설정이 필요합니다.(local, prod에서만 redis 적용)
   <img width="1504" height="33" alt="스크린샷 2026-02-09 오후 4 10 13" src="https://github.com/user-attachments/assets/8b60b4c1-25dc-4709-843a-5f4146f72a88" /> 
   인텔리제이 상단의 ...(more actions) 클릭 -> edit 클릭 -> active profiles에 local 입력
- Redis를 적용하여도 최초 조회시에는 시간이 다소 소요됩니다. 다만 동일 조건으로 재검색시 이전 대비 성능이 많이 향상하였습니다.
- 배포 서버에도 Redis 적용 진행중입니다. 이와 관련된 내용은 추후 새로운 pr로 올리겠습니다.