### PR TITLE
[Fix] 회원가입 시 생년월일 입력 추가

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/umc/barkit/domain/user/converter/UserConverter.java
@@ -24,7 +24,7 @@ public class UserConverter {
                 .passwordHash(passwordHash)
                 .role(role)
                 .phoneNumber(null)
-                .birthDate(null)
+                .birthDate(dto.birthDate())
                 .status(UserStatus.ACTIVE) // 초기 상태는 ACTIVE
                 .deletedAt(null) // 삭제 시간은 null
                 .build();

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -30,6 +30,12 @@ public class UserRequestDto {
             String password,
             @NotBlank
             String confirmPassword,
+            @NotNull
+            @PastOrPresent
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+            @Schema(example = "2002-01-01")
+            LocalDate birthDate,
+
             @NotEmpty
             @Valid
             List<TermAgreement> terms


### PR DESCRIPTION
## #️⃣ 기능 설명
회원가입 시 생년월일(birthDate)을 함께 입력받아 User에 저장

## 🛠️ 작업 상세 내용
- [x] SignupRequestDto에 birthDate(LocalDate) 필드 추가
- [x] UserConverter.toUser()에서 birthDate를 dto.birthDate()로 매핑하여 저장

## 📸 스크린샷 (선택)
1. 회원가입
<img width="896" height="733" alt="image" src="https://github.com/user-attachments/assets/a509f1ad-f38f-42cf-9883-842922ef4207" />
<img width="868" height="178" alt="image" src="https://github.com/user-attachments/assets/fc5881cc-b7a2-460b-870f-72fa2bdf724b" />

2. 개인정보 조회 확인
<img width="857" height="233" alt="image" src="https://github.com/user-attachments/assets/fddbefe8-a7c8-4cd7-addf-eb38a35662d2" />


## 💬 기타(공유사항 to 리뷰어)