### PR TITLE
✨ [Feat] 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -11,6 +11,7 @@ import com.umc.barkit.global.auth.details.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -169,5 +170,12 @@ public class UserController implements UserControllerDocs{
         );
     }
 
+    // 회원 탈퇴
+    @DeleteMapping("/users/me")
+    public ApiResponse<UserResponseDto.WithdrawResponseDto> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ApiResponse.onSuccess(UserSuccessCode.WITHDRAW_OK, userCommandService.withdraw(userDetails.getUserId()));
+    }
 
 }

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -192,4 +192,20 @@ public interface UserControllerDocs {
             @RequestBody @Valid UserRequestDto.NaverLoginRequestDto request
     );
 
+    @Operation(
+            summary = "회원 탈퇴 API",
+            description = """
+                    로그인된 사용자의 계정을 탈퇴 처리합니다.<br>
+                    <b>Soft Delete</b> 방식으로 처리되며, 사용자 상태를 비활성화하고 deletedAt을 기록합니다.<br>
+                    또한, 사용자의 모든 활성 세션(Refresh Token)을 무효화하고, 탈퇴 후에는 기존 Access/Refresh Token으로 인증이 불가능합니다.
+                    """
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "회원 탈퇴 실패")
+    })
+    ApiResponse<UserResponseDto.WithdrawResponseDto> withdraw(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
+
 }

--- a/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/res/UserResponseDto.java
@@ -1,6 +1,7 @@
 package com.umc.barkit.domain.user.dto.res;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.Builder;
 
 public class UserResponseDto {
@@ -37,5 +38,11 @@ public class UserResponseDto {
             String email,
             String phoneNumber,
             LocalDate birthDate
+    ) {}
+
+    // 회원 탈퇴
+    public record WithdrawResponseDto(
+            Long userId,
+            LocalDateTime deletedAt
     ) {}
 }

--- a/src/main/java/com/umc/barkit/domain/user/entity/User.java
+++ b/src/main/java/com/umc/barkit/domain/user/entity/User.java
@@ -54,9 +54,10 @@ public class User extends BaseEntity {
     @Column(name = "location_consent", nullable = false)
     private Boolean locationConsent = false;
 
-    public void softDelete() {
-        this.deletedAt = LocalDateTime.now();
+    public void softDelete(String anonymizedEmail, LocalDateTime now) {
+        this.deletedAt = now;
         this.status = UserStatus.INACTIVE;
+        this.email = anonymizedEmail;
     }
 
     // 생년월일 변경

--- a/src/main/java/com/umc/barkit/domain/user/entity/UserOauth.java
+++ b/src/main/java/com/umc/barkit/domain/user/entity/UserOauth.java
@@ -45,7 +45,8 @@ public class UserOauth {
         return disconnectedAt != null;
     }
 
-    public void disconnect() {
-        this.disconnectedAt = LocalDateTime.now();
+    public void disconnect(String anonymizedProviderUid, LocalDateTime now) {
+        this.disconnectedAt = now;
+        this.providerUid = anonymizedProviderUid;
     }
 }

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
@@ -21,8 +21,9 @@ public enum UserSuccessCode implements BaseSuccessCode {
     PASSWORD_UPDATED(HttpStatus.OK, "USER2002", "비밀번호 변경에 성공했습니다."),
 
     NOTIFICATION_UPDATED(HttpStatus.OK, "USER2005", "알림 설정이 변경되었습니다."),
-    LOCATION_CONSENT_UPDATED(HttpStatus.OK, "USER2006", "위치 권한 동의 상태가 변경되었습니다.");
+    LOCATION_CONSENT_UPDATED(HttpStatus.OK, "USER2006", "위치 권한 동의 상태가 변경되었습니다."),
 
+    WITHDRAW_OK(HttpStatus.OK, "USER2007", "회원탈퇴가 완료되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/umc/barkit/domain/user/repository/UserOauthRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/UserOauthRepository.java
@@ -2,6 +2,7 @@ package com.umc.barkit.domain.user.repository;
 
 import com.umc.barkit.domain.user.entity.UserOauth;
 import com.umc.barkit.domain.user.enums.AuthProvider;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,5 @@ import org.springframework.stereotype.Repository;
 public interface UserOauthRepository extends JpaRepository<UserOauth, Long> {
 
     Optional<UserOauth> findByProviderAndProviderUidAndDisconnectedAtIsNull(AuthProvider provider, String providerUid);
+    List<UserOauth> findAllByUser_IdAndDisconnectedAtIsNull(Long userId);
 }

--- a/src/main/java/com/umc/barkit/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.umc.barkit.domain.user.repository;
 
 import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.enums.UserStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,6 +9,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    boolean existsByEmail(String email);  // 아이디(이메일) 중복 확인
+    boolean existsByEmailAndStatus(String email, UserStatus status); // 아이디(이메일) 중복 확인
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByEmailAndStatus(String email, UserStatus status);
+
+    Optional<User> findByIdAndStatus(Long id, UserStatus status);
 }

--- a/src/main/java/com/umc/barkit/domain/user/repository/UserSessionRepository.java
+++ b/src/main/java/com/umc/barkit/domain/user/repository/UserSessionRepository.java
@@ -14,4 +14,12 @@ import org.springframework.stereotype.Repository;
 public interface UserSessionRepository extends JpaRepository<UserSession, Long> {
     Optional<UserSession> findByUserAndRefreshTokenHashAndRevokedAtIsNull(User user, String refreshTokenHash);
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update UserSession us
+           set us.revokedAt = :now
+         where us.user.id = :userId
+           and us.revokedAt is null
+    """)
+    int revokeAllActiveByUserId(@Param("userId") Long userId, @Param("now") LocalDateTime now);
 }

--- a/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
@@ -5,15 +5,21 @@ import com.umc.barkit.domain.user.dto.req.UserRequestDto;
 import com.umc.barkit.domain.user.dto.res.UserResponseDto;
 import com.umc.barkit.domain.user.entity.Term;
 import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.entity.UserOauth;
 import com.umc.barkit.domain.user.entity.mapping.UserTerm;
 import com.umc.barkit.domain.user.enums.Role;
+import com.umc.barkit.domain.user.enums.UserStatus;
 import com.umc.barkit.domain.user.exception.UserException;
 import com.umc.barkit.domain.user.exception.code.UserErrorCode;
 import com.umc.barkit.domain.user.repository.TermRepository;
+import com.umc.barkit.domain.user.repository.UserOauthRepository;
 import com.umc.barkit.domain.user.repository.UserRepository;
+import com.umc.barkit.domain.user.repository.UserSessionRepository;
 import com.umc.barkit.domain.user.repository.UserTermRepository;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -27,13 +33,15 @@ public class UserCommandService {
     private final UserRepository userRepository;
     private final UserTermRepository userTermRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserSessionRepository userSessionRepository;
+    private final UserOauthRepository userOauthRepository;
 
     // 회원가입
     @Transactional
     public UserResponseDto.SignupResponseDto signup(UserRequestDto.SignupRequestDto signupRequestDto){
 
         // 이메일 중복 확인
-        if (userRepository.existsByEmail(signupRequestDto.email())) {
+        if (userRepository.existsByEmailAndStatus(signupRequestDto.email(), UserStatus.ACTIVE)) {
             throw new UserException(UserErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
@@ -65,7 +73,7 @@ public class UserCommandService {
     // 생년월일 변경
     @Transactional
     public void updateBirthDate(Long userId, LocalDate birthDate){
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
         user.updateBirthDate(birthDate);
@@ -75,7 +83,7 @@ public class UserCommandService {
     @Transactional
     public void updatePassword(Long userId, UserRequestDto.UpdatePasswordRequestDto request){
         // 현재 비밀번호 검증
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
         // 현재 비밀번호와 입력한 비밀번호 비교
@@ -106,7 +114,7 @@ public class UserCommandService {
     // 알림 설정 변경
     @Transactional
     public void updateNotification(Long userId, Boolean enabled) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
         user.updateNotificationEnabled(enabled);
@@ -115,9 +123,31 @@ public class UserCommandService {
     // 위치 권한 동의 상태 변경
     @Transactional
     public void updateLocationConsent(Long userId, Boolean consented) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
         user.updateLocationConsent(consented);
+    }
+
+    // 회원 탈퇴
+    @Transactional
+    public UserResponseDto.WithdrawResponseDto withdraw(Long userId) {
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        LocalDateTime now = LocalDateTime.now();
+
+        String anonymizedEmail = "deleted_" + user.getId() + "_" + UUID.randomUUID() + "@barkit.invalid";
+        user.softDelete(anonymizedEmail, now);
+
+        userSessionRepository.revokeAllActiveByUserId(userId, now);
+
+        List<UserOauth> oauthList = userOauthRepository.findAllByUser_IdAndDisconnectedAtIsNull(userId);
+        for (UserOauth oauth : oauthList) {
+            String anonymizedUid = "deleted_" + userId + "_" + UUID.randomUUID();
+            oauth.disconnect(anonymizedUid, now);
+        }
+
+        return new UserResponseDto.WithdrawResponseDto(user.getId(), user.getDeletedAt());
     }
 }

--- a/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/query/UserQueryService.java
@@ -9,6 +9,7 @@ import com.umc.barkit.domain.user.entity.UserOauth;
 import com.umc.barkit.domain.user.entity.UserSession;
 import com.umc.barkit.domain.user.enums.AuthProvider;
 import com.umc.barkit.domain.user.enums.Role;
+import com.umc.barkit.domain.user.enums.UserStatus;
 import com.umc.barkit.domain.user.exception.UserException;
 import com.umc.barkit.domain.user.exception.code.UserErrorCode;
 import com.umc.barkit.domain.user.oauth.client.KakaoApiClient;
@@ -46,7 +47,7 @@ public class UserQueryService {
 
     // 아이디 중복 확인
     public UserResponseDto.EmailCheckResponseDto checkEmailAvailability(String email) {
-        boolean isAvailable = !userRepository.existsByEmail(email); // DB에서 해당 이메일이 존재하면 false 반환
+        boolean isAvailable = !userRepository.existsByEmailAndStatus(email, UserStatus.ACTIVE); // DB에서 해당 이메일이 존재하면 false 반환
         String message = isAvailable ? "사용 가능한 아이디입니다" : "사용 불가능한 아이디입니다";
         return new EmailCheckResponseDto(isAvailable, message);
     }
@@ -58,7 +59,7 @@ public class UserQueryService {
     ) {
 
         // User 조회
-        User user = userRepository.findByEmail(dto.email())
+        User user = userRepository.findByEmailAndStatus(dto.email(), UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
         // 비밀번호 검증
@@ -119,7 +120,7 @@ public class UserQueryService {
         }
 
         // 이메일로 User 조회
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByEmailAndStatus(email, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
         // 리프레쉬 토큰 해시화
@@ -143,12 +144,8 @@ public class UserQueryService {
 
     // 개인정보 조회
     public UserResponseDto.PersonalInfoResponseDto getPersonalInfo(Long userId) {
-        User user = userRepository.findById(userId)
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
-
-        if (user.getDeletedAt() != null) {
-            throw new UserException(UserErrorCode.NOT_FOUND);
-        }
 
         return UserConverter.toPersonalInfoDto(user);
     }
@@ -169,7 +166,7 @@ public class UserQueryService {
             throw new UserException(UserErrorCode.REFRESH_TOKEN_INVALID);
         }
 
-        User user = userRepository.findByEmail(email)
+        User user = userRepository.findByEmailAndStatus(email, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
         String refreshTokenHash = jwtUtil.hashToken(refreshToken);
@@ -209,6 +206,7 @@ public class UserQueryService {
         User user = userOauthRepository
                 .findByProviderAndProviderUidAndDisconnectedAtIsNull(AuthProvider.KAKAO, providerUid)
                 .map(UserOauth::getUser)
+                .filter(u -> u.getStatus() == UserStatus.ACTIVE)
                 .orElseGet(() -> upsertUserAndConnectOauth(AuthProvider.KAKAO, email, nickname, providerUid));
 
         // JWT 발급
@@ -217,7 +215,8 @@ public class UserQueryService {
 
     private User upsertUserAndConnectOauth(AuthProvider provider, String email, String nickname, String providerUid) {
         // 이메일 기반으로 우리 서비스 유저가 이미 있으면 재사용
-        User user = userRepository.findByEmail(email).orElseGet(() -> createSocialUser(email, nickname));
+        User user = userRepository.findByEmailAndStatus(email, UserStatus.ACTIVE)
+                .orElseGet(() -> createSocialUser(email, nickname));
 
         // user_oauth에 (KAKAO, providerUid) 연결 정보 저장
         UserOauth oauth = UserOauth.builder()
@@ -309,6 +308,7 @@ public class UserQueryService {
         User user = userOauthRepository
                 .findByProviderAndProviderUidAndDisconnectedAtIsNull(AuthProvider.NAVER, providerUid)
                 .map(UserOauth::getUser)
+                .filter(u -> u.getStatus() == UserStatus.ACTIVE)
                 .orElseGet(() -> upsertUserAndConnectOauth(AuthProvider.NAVER, email, name, providerUid));
 
         return issueTokens(user);

--- a/src/main/java/com/umc/barkit/global/auth/details/CustomUserDetailsService.java
+++ b/src/main/java/com/umc/barkit/global/auth/details/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package com.umc.barkit.global.auth.details;
 
 import com.umc.barkit.domain.user.entity.User;
+import com.umc.barkit.domain.user.enums.UserStatus;
 import com.umc.barkit.domain.user.exception.UserException;
 import com.umc.barkit.domain.user.exception.code.UserErrorCode;
 import com.umc.barkit.domain.user.repository.UserRepository;
@@ -22,7 +23,7 @@ public class CustomUserDetailsService implements UserDetailsService {
             String username
     ) throws UsernameNotFoundException {
         // 검증할 Member 조회
-        User user = userRepository.findByEmail(username)
+        User user = userRepository.findByEmailAndStatus(username, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
         // CustomUserDetails 반환
         return new CustomUserDetails(user);

--- a/src/main/java/com/umc/barkit/global/auth/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/umc/barkit/global/auth/jwt/JwtAuthFilter.java
@@ -43,14 +43,19 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             // 토큰에서 이메일 추출
             String email = jwtUtil.getEmail(token);
             // 인증 객체 생성: 이메일로 찾아온 뒤, 인증 객체 생성
-            UserDetails user = customUserDetailsService.loadUserByUsername(email);
-            Authentication auth = new UsernamePasswordAuthenticationToken(
-                    user,
-                    null,
-                    user.getAuthorities()
-            );
-            // 인증 완료 후 SecurityContextHolder에 넣기
-            SecurityContextHolder.getContext().setAuthentication(auth);
+
+            try{
+                UserDetails user = customUserDetailsService.loadUserByUsername(email);
+                Authentication auth = new UsernamePasswordAuthenticationToken(
+                        user,
+                        null,
+                        user.getAuthorities()
+                );
+                // 인증 완료 후 SecurityContextHolder에 넣기
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }catch(RuntimeException e){
+                SecurityContextHolder.clearContext();
+            }
         }
         filterChain.doFilter(request, response);
 


### PR DESCRIPTION
## #️⃣ 기능 설명
회원 탈퇴(Soft Delete) API 구현

## 🛠️ 작업 상세 내용
- [x] 회원 탈퇴 API 구현 (Soft Delete + deletedAt 기록)
- [x] 탈퇴 시 사용자 email 익명화 처리(deleted_{userId}_{uuid}@barkit.invalid)로 재가입 허용
- [x] 탈퇴 시 user_sessions 전체 revoke 처리 및 user_oauth 연결 해제
- [x] 로그인/재발급/회원가입/이메일중복확인 등 조회 로직에서 UserStatus.ACTIVE 기준으로 조회하도록 정리

## 📸 스크린샷 (선택)
**[일반 로그인 테스트]**
1. 회원가입
<img width="525" height="203" alt="image" src="https://github.com/user-attachments/assets/f5fa3efe-47c8-4471-bffc-859f9ed601c0" />

2. 로그인 성공
<img width="435" height="160" alt="image" src="https://github.com/user-attachments/assets/44b6bb43-20eb-4811-96bf-f7c9160e360c" />

3. 회원 탈퇴
<img width="477" height="212" alt="image" src="https://github.com/user-attachments/assets/7c4c0d2f-ff2b-4be2-b1ca-f1b6b4b403a8" />

* user 테이블에서 INACTIVE, deleted_at , email이 변경된 모습
<img width="795" height="32" alt="image" src="https://github.com/user-attachments/assets/51f3f6a0-74fd-41f9-a1ae-131a8ebd1620" />
<img width="402" height="40" alt="image" src="https://github.com/user-attachments/assets/4e41cd84-0d6d-4a2d-a110-fd600a6acee1" />

4. 회원탈퇴 후 기존 accessToken으로 개인 정보 조회 할 경우
<img width="382" height="177" alt="image" src="https://github.com/user-attachments/assets/30af4cb5-5dec-4a7f-8853-6c657449f243" />

5. 회원탈퇴 후 refresh로 재발급 시도
<img width="431" height="177" alt="image" src="https://github.com/user-attachments/assets/41d017d7-c190-44bb-91bf-66b5af171adb" />

6. user_sessions 테이블에서 해당 유저의 revoked_at이 찍혀있는 모습
<img width="495" height="27" alt="image" src="https://github.com/user-attachments/assets/04a13f65-af9f-4a5c-983f-bc60c24eb96f" />

7. 같은 이메일로 재가입 가능
<img width="500" height="202" alt="image" src="https://github.com/user-attachments/assets/95b947b3-7ffe-45d3-8350-1acc39c2b1ed" />
<img width="445" height="237" alt="image" src="https://github.com/user-attachments/assets/3be329a9-d31a-4d2f-b8f6-61b5f70416a5" />

[카카오 소셜 로그인(네이버도 동일하게 테스트 완료)]
1. 카카오 로그인
<img width="1217" height="42" alt="image" src="https://github.com/user-attachments/assets/292d3c67-7a02-4336-8e1a-6ac8921841ac" />
<img width="443" height="232" alt="image" src="https://github.com/user-attachments/assets/c212243f-3b06-423c-aa81-f394f45b86a9" />

2. 회원 탈퇴
<img width="462" height="201" alt="image" src="https://github.com/user-attachments/assets/b8840288-9d20-4618-a704-33ee27110b81" />

* user 테이블에서 INACTIVE, deleted_at , email이 변경된 모습
<img width="1240" height="47" alt="image" src="https://github.com/user-attachments/assets/e1eab010-fe71-4502-93c3-c48ed3268295" />

* user_oauth테이블에서  disconnected_at 채워지고 provider_uid가 deleted_...로 바뀐 모습
<img width="845" height="32" alt="image" src="https://github.com/user-attachments/assets/522ee930-8377-4186-93e5-b5956e8898e8" />

3. 회원 탈퇴 후 같은 소셜 계정으로 재가입 가능
<img width="1220" height="36" alt="image" src="https://github.com/user-attachments/assets/58aeec34-9975-4b43-85ee-1c48ca72073c" />


## 💬 기타(공유사항 to 리뷰어)
* 회원 탈퇴 후 동일한 이메일로 재가입은 허용시켜두었습니다. 
* 탈퇴 시 email을 더미 값으로 변경해 unique 충돌을 방지했습니다.