### PR TITLE
[Fix] 멤버십 기준 매장 조회를 store_brand 기준으로 수정

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
+++ b/src/main/java/com/umc/barkit/domain/membership/controller/UserMembershipBrandController.java
@@ -132,8 +132,8 @@ public class UserMembershipBrandController {
 
     @Operation(
             summary = "멤버십 기준 적립/할인 가능 매장 조회",
-            description = "로그인한 사용자가 보유한 특정 멤버십으로 적립/할인 가능한 매장 목록을 조회합니다. " +
-                    "검색어(keyword)를 통해 매장명 검색이 가능하며, cursor 기반 페이징을 지원합니다."
+            description = "로그인한 사용자가 보유한 특정 멤버십으로 적립/할인 가능한 매장(브랜드) 목록을 조회합니다. " +
+                    "검색어(keyword)를 통해 브랜드명 검색이 가능하며, cursor 기반 페이징을 지원합니다."
     )
     @GetMapping("/{userMembershipBrandId}/stores")
     public ResponseEntity<ApiResponse<UserMembershipBrandResponseDTO.AvailableStoreListDTO>> getAvailableStores(

--- a/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
+++ b/src/main/java/com/umc/barkit/domain/membership/converter/UserMembershipBrandConverter.java
@@ -113,22 +113,6 @@ public class UserMembershipBrandConverter {
                 .build();
     }
 
-    /* =========================
-       사용 가능 매장 조회(브랜드)
-     ========================= */
-    public UserMembershipBrandResponseDTO.AvailableStoreDTO
-    toAvailableStoreDTO(Store store) {
-
-        StoreBrand brand = store.getBrand();
-
-        return UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
-                .storeId(store.getId())          // 내부용 (cursor용)
-                //.storeName(null)               // 지점명 없음
-                .brandName(brand.getName())      // 브랜드명
-                .logoUrl(brand.getLogoUrl())
-                //.address(null)
-                .build();
-    }
 }
 
 

--- a/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
+++ b/src/main/java/com/umc/barkit/domain/membership/dto/response/UserMembershipBrandResponseDTO.java
@@ -62,7 +62,8 @@ public class UserMembershipBrandResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class AvailableStoreDTO {
-        private Long storeId;
+        // storeId  → storeBrandId
+        private Long storeBrandId;
         private String brandName;
         private String logoUrl;
     }

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -138,7 +138,7 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
                     .build();
         }
 
-        // 4. StoreBrand 조회 (지점 존재하는 브랜드만)
+        // 4. StoreBrand 조회 (store 테이블 의존 제거)
         List<StoreBrand> brands =
                 storeBrandRepository.findAvailableStoreBrands(
                         storeBrandIds,
@@ -157,21 +157,16 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
                 ? resultBrands.get(resultBrands.size() - 1).getId()
                 : null;
 
-        // 5. DTO 변환 (대표 store 1개만 사용)
+        // 5. DTO 변환 (StoreBrand 기준)
         List<UserMembershipBrandResponseDTO.AvailableStoreDTO> storeDTOs =
                 resultBrands.stream()
-                        .map(brand -> {
-                            Long storeId =
-                                    storeRepository
-                                            .findStoreIdsByBrandId(brand.getId(), PageRequest.of(0, 1))
-                                            .get(0);
-
-                            return UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
-                                    .storeId(storeId)
-                                    .brandName(brand.getName())
-                                    .logoUrl(brand.getLogoUrl())
-                                    .build();
-                        })
+                        .map(brand ->
+                                UserMembershipBrandResponseDTO.AvailableStoreDTO.builder()
+                                        .storeBrandId(brand.getId())
+                                        .brandName(brand.getName())
+                                        .logoUrl(brand.getLogoUrl())
+                                        .build()
+                        )
                         .toList();
 
         return UserMembershipBrandResponseDTO.AvailableStoreListDTO.builder()

--- a/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandRepository.java
+++ b/src/main/java/com/umc/barkit/domain/store/repository/StoreBrandRepository.java
@@ -54,12 +54,7 @@ public interface StoreBrandRepository extends JpaRepository<StoreBrand,Long> {
     select sb
     from StoreBrand sb
     where sb.id in :storeBrandIds
-      and exists (
-          select 1
-          from Store s
-          where s.brand = sb
-            and (:cursor is null or sb.id > :cursor)
-      )
+      and (:cursor is null or sb.id > :cursor)
       and (:keyword is null
            or lower(sb.name) like lower(concat('%', :keyword, '%')))
     order by sb.id asc


### PR DESCRIPTION
## #️⃣ 기능 설명
> 멤버십 기준 적립/할인 가능 매장 조회 API를  
> store 테이블이 아닌 store_brand 기준으로 조회하도록 리팩토링했습니다.
Close #117 
## 🛠️ 작업 상세 내용
- [x] 멤버십 기준 매장 조회 로직에서 store 테이블 의존 제거
- [x] store_brand_membership_brand → store_brand 기준으로 조회 로직 수정
- [x] 지점(store) 존재 여부와 무관하게 정책 기준 브랜드 조회 가능하도록 개선
- [x] 응답 DTO를 storeBrand 기준으로 정리 (`storeBrandId`)

## 📸 스크린샷 (선택)
*** 1-4는 원래 있던 기능입니다!!! *** 
- Swagger   `GET /api/user-membership-brands/{userMembershipBrandId}/stores`
- 테스트 값 `userMembershipBrandId = 15`

1. 기본 조회 (size는 default 20)
<img width="1710" height="1386" alt="image" src="https://github.com/user-attachments/assets/a045dda5-6ee8-4886-baa7-9969cd70cb32" />

2. size 조회
<img width="1406" height="2007" alt="image" src="https://github.com/user-attachments/assets/078ae666-84f4-4bf5-8d50-48b4a61f7fe6" />

3. 키워드 조회
<img width="1542" height="1809" alt="image" src="https://github.com/user-attachments/assets/6fe210a2-6b91-4b83-a721-ffa4c9b72d93" />
<img width="1542" height="1809" alt="image" src="https://github.com/user-attachments/assets/6fe210a2-6b91-4b83-a721-ffa4c9b72d93" />

4. 커서기반 조회
<img width="1406" height="2007" alt="image" src="https://github.com/user-attachments/assets/d5fda204-3236-4c46-9b6d-cd1cc5efaebc" />


5. 기존에 stroe 테이블에 존재하지 않는 store 브랜드이면 조회가 불가능 했었음(store테이블 기준으로 조회하므로)
<img width="1204" height="776" alt="image" src="https://github.com/user-attachments/assets/103f9c12-1444-4aab-978a-4b6e250afa8c" />
<img width="1086" height="788" alt="image" src="https://github.com/user-attachments/assets/c7046028-903b-4f99-b4e4-b706b83c32d4" />
store테이블에 없으면 테스트 브랜드 나오지 않음

stor_brand 기준 조회로 변경 후 
<img width="1183" height="1440" alt="image" src="https://github.com/user-attachments/assets/0c97d6a9-865a-4b4c-ba93-af6b4c2a9602" />
테스트 브랜드 나오는 것을 볼 수 있음


## 💬 기타(공유사항 to 리뷰어)
- 기존에는 store(지도 검색 시 동적 생성 데이터) 존재 여부에 따라 멤버십 정책 결과가 달라지는 문제가 있었습니다.
- 따라서 (store_brand_membership_brand)을 조회 기준으로 사용하여, DB 초기 상태에서도 일관된 결과를 보장하도록 개선했습니다.