### PR TITLE
[fix] 배포 서버 Redis 적용 실패 오류 원인 파악을 위한 로그 출력

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -74,6 +74,9 @@ jobs:
           
           jar_file=$(find build/libs -name '*.jar' ! -name '*plain.jar' | head -n 1)
           
+          ssh -vvv -i private_key.pem -o StrictHostKeyChecking=no \
+            $EC2_USERNAME@$EC2_HOST "echo SSH_OK && whoami && hostname"
+  
           scp -i private_key.pem -o StrictHostKeyChecking=no "$jar_file" \
             $EC2_USERNAME@$EC2_HOST:/home/$EC2_USERNAME/umcBarkitServer.jar
           


### PR DESCRIPTION
## #️⃣ 기능 설명
> 배포 서버에 Redis 적용 실패 오류 원인 파악을 위한 로그 출력하는 코드를 추가합니다.

## 🛠️ 작업 상세 내용
- [x] dev_deploy.yml 파일에
```
ssh -vvv -i private_key.pem -o StrictHostKeyChecking=no \
            $EC2_USERNAME@$EC2_HOST "echo SSH_OK && whoami && hostname"
```
추가


## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)