### PR TITLE
[Fix] UserMembershipBrand isMain 기본값 null 방지

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
+++ b/src/main/java/com/umc/barkit/domain/membership/entity/UserMembershipBrand.java
@@ -25,6 +25,7 @@ public class UserMembershipBrand extends BaseEntity {
     @Column(name = "membership_number", nullable = false, length = 30)
     private String membershipNumber;
 
+    @Builder.Default
     @Column(name = "is_main", nullable = false)
     private Boolean isMain = false;
 


### PR DESCRIPTION
## #️⃣ 기능 설명
> UserMembershipBrand 엔티티의 isMain 필드에 @Builder.Default를 적용하여 기본값이 null로 설정되는 문제를 방지했습니다.

## 🛠️ 작업 상세 내용
- [x] isMain 필드에 @Builder.Default 추가
- [x] 빌더 사용 시 기본값(false) 유지하도록 수정


## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
빌더 사용 시 isMain이 null로 초기화될 수 있어 DB nullable = false와 충돌 가능성이 있어 수정했습니다.