### PR TITLE
[Feat]멤버십 브랜드 id 반환 추가

### DIFF
--- a/src/main/java/com/umc/barkit/domain/store/dto/res/StoreResDTO.java
+++ b/src/main/java/com/umc/barkit/domain/store/dto/res/StoreResDTO.java
@@ -78,7 +78,8 @@ public class StoreResDTO {
     @Builder
     public record MembershipInfo(
             String name,
-            String logoUrl
+            String logoUrl,
+            Long id
     ){}
 
     @Builder
@@ -91,7 +92,8 @@ public class StoreResDTO {
     @Builder
     public record UserMembershipInfo(
             String name,
-            String logoUrl
+            String logoUrl,
+            Long id
     ){}
 
 }

--- a/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
@@ -202,6 +202,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
                 .map(m -> StoreResDTO.MembershipInfo.builder()
                         .name(m.getMembershipBrand().getName())
                         .logoUrl(m.getMembershipBrand().getLogoUrl())
+                        .id(m.getMembershipBrand().getId())
                         .build())
                 .toList();
 
@@ -229,6 +230,7 @@ public class StoreQueryServiceImpl implements StoreQueryService{
                     return StoreResDTO.UserMembershipInfo.builder()
                             .name(brand.getName())
                             .logoUrl(brand.getLogoUrl())
+                            .id(brand.getId())
                             .build();
                 })
                 .toList();


### PR DESCRIPTION
## #️⃣ 기능 설명
> 상세 조회 시 멤버십 브랜드 id 반환 추가

## 🛠️ 작업 상세 내용
- [x] StoreQueryServiceImpl에 로직 추가

## 📸 스크린샷 (선택)
+ userMembership과 membership에 모두 멤버십 id 추가
<img width="1169" height="508" alt="스크린샷 2026-02-11 오후 5 28 23" src="https://github.com/user-attachments/assets/ad5ed0a8-79d4-446a-a1f4-e4746e77a46c" />


## 💬 기타(공유사항 to 리뷰어)