### PR TITLE
[Refactor]id 반환값 수정

### DIFF
--- a/src/main/java/com/umc/barkit/domain/store/dto/res/StoreResDTO.java
+++ b/src/main/java/com/umc/barkit/domain/store/dto/res/StoreResDTO.java
@@ -78,8 +78,7 @@ public class StoreResDTO {
     @Builder
     public record MembershipInfo(
             String name,
-            String logoUrl,
-            Long id
+            String logoUrl
     ){}
 
     @Builder
@@ -93,7 +92,8 @@ public class StoreResDTO {
     public record UserMembershipInfo(
             String name,
             String logoUrl,
-            Long id
+            Long userMembershipId,
+            Long membershipBrandId
     ){}
 
 }

--- a/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/store/service/query/StoreQueryServiceImpl.java
@@ -202,7 +202,6 @@ public class StoreQueryServiceImpl implements StoreQueryService{
                 .map(m -> StoreResDTO.MembershipInfo.builder()
                         .name(m.getMembershipBrand().getName())
                         .logoUrl(m.getMembershipBrand().getLogoUrl())
-                        .id(m.getMembershipBrand().getId())
                         .build())
                 .toList();
 
@@ -214,23 +213,26 @@ public class StoreQueryServiceImpl implements StoreQueryService{
         List<UserMembershipBrand> userMembershipEntities = userMembershipBrandRepository.findByUserId(userId);
 
 
-        List<Long> userMembershipBrandIds = userMembershipEntities.stream()
-                .map(UserMembershipBrand::getMembershipBrandId)
-                .toList();
-
+        Map<Long, Long> brandIdToUserMembershipId = userMembershipEntities.stream()
+                .collect(Collectors.toMap(
+                        UserMembershipBrand::getMembershipBrandId,   // key: membershipBrandId
+                        UserMembershipBrand::getId                   // value: user_membership_brand PK
+                ));
 
         List<Long> intersectionIds = storeMembershipBrandIds.stream()
-                .filter(userMembershipBrandIds::contains)
+                .filter(brandIdToUserMembershipId::containsKey)
                 .toList();
 
         List<StoreResDTO.UserMembershipInfo> userMembershipInfos = intersectionIds.stream()
-                .map(id -> {
-                    MembershipBrand brand = membershipBrandRepository.findById(id)
+                .map(brandId -> {
+                    MembershipBrand brand = membershipBrandRepository.findById(brandId)
                             .orElseThrow(() -> new MembershipException(MembershipErrorCode.BRAND4001));
+
                     return StoreResDTO.UserMembershipInfo.builder()
+                            .userMembershipId(brandIdToUserMembershipId.get(brandId))
+                            .membershipBrandId(brandId)
                             .name(brand.getName())
                             .logoUrl(brand.getLogoUrl())
-                            .id(brand.getId())
                             .build();
                 })
                 .toList();


### PR DESCRIPTION
## #️⃣ 기능 설명
> 기존 반환 값이었던 membership_brand_id에서 userMembershipId 반환 추가

## 🛠️ 작업 상세 내용
- [x] StoreQueryServiceImpl 로직 수정

## 📸 스크린샷 (선택)
<img width="1002" height="493" alt="스크린샷 2026-02-11 오후 6 46 41" src="https://github.com/user-attachments/assets/f5c2f80f-e7be-460a-8064-1efdd1cb9e3a" />
> userId : 114
<img width="670" height="19" alt="스크린샷 2026-02-11 오후 6 47 12" src="https://github.com/user-attachments/assets/c998bc06-6c72-41e0-8366-eb60d6fe3847" />
> 114 유저가 등록한 멤버십 및 userMembershipId
<img width="768" height="31" alt="스크린샷 2026-02-11 오후 6 47 53" src="https://github.com/user-attachments/assets/42721d5a-9e56-4d39-915a-e41bc0d16a06" />

## 💬 기타(공유사항 to 리뷰어)