### PR TITLE
[Refactor] error code structure

### DIFF
--- a/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/home/service/HomeDashboardServiceImpl.java
@@ -5,6 +5,8 @@ import com.umc.barkit.domain.membership.entity.MembershipBrand;
 import com.umc.barkit.domain.membership.entity.UserMembershipBrand;
 import com.umc.barkit.domain.membership.repository.MembershipBrandRepository;
 import com.umc.barkit.domain.membership.repository.UserMembershipBrandRepository;
+import com.umc.barkit.global.apiPayload.code.GeneralErrorCode;
+import com.umc.barkit.global.apiPayload.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -73,6 +75,10 @@ public class HomeDashboardServiceImpl implements HomeDashboardService {
                         .map(umb -> {
                             MembershipBrand brand =
                                     membershipBrandMap.get(umb.getMembershipBrandId());
+
+                            if (brand == null) {
+                                throw new GeneralException(GeneralErrorCode.HOME4001);
+                            }
 
                             return HomeDashboardResponse.MembershipSummaryDTO.builder()
                                     .userMembershipBrandId(umb.getId())

--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -116,10 +116,10 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
         UserMembershipBrand umb =
                 userMembershipBrandRepository.findById(userMembershipBrandId)
                         .orElseThrow(() ->
-                                new MembershipException(MembershipErrorCode.MEMBERSHIP4001));
+                                new MembershipException(MembershipErrorCode.MEMBERSHIP4004));
 
         if (!umb.getUserId().equals(userId)) {
-            throw new MembershipException(MembershipErrorCode.MEMBERSHIP4003);
+            throw new MembershipException(MembershipErrorCode.MEMBERSHIP4005);
         }
 
         // 2. 멤버십 브랜드 ID

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -98,11 +98,13 @@ public class UserRequestDto {
     }
 
     // 알림 설정 변경
+    @NotNull
     public record UpdateNotificationRequestDto(
             Boolean enabled
     ) {}
 
     // 위치 권한 동의 변경
+    @NotNull
     public record UpdateLocationConsentRequestDto(
             Boolean consented
 

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserErrorCode.java
@@ -34,6 +34,7 @@ public enum UserErrorCode implements BaseErrorCode {
 
     // 사용자
     NOT_FOUND(HttpStatus.NOT_FOUND, "USER4004", "사용자를 찾을 수 없습니다."),
+    INACTIVE_USER(HttpStatus.FORBIDDEN, "USER4005", "탈퇴한 사용자는 해당 기능을 사용할 수 없습니다."),
 
     // 소셜 연동
     OAUTH_ALREADY_CONNECTED(HttpStatus.CONFLICT, "OAUTH4001", "이미 해당 소셜 계정이 연동되어 있습니다."),

--- a/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
@@ -117,6 +117,17 @@ public class UserCommandService {
         User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
 
+        // 1️. INACTIVE 유저 차단
+        if (user.getStatus() == UserStatus.INACTIVE) {
+            throw new UserException(UserErrorCode.INACTIVE_USER);
+        }
+
+
+        // 2. 동일 상태 요청 방어
+        if (Boolean.TRUE.equals(user.getNotificationEnabled()) == enabled) {
+            return;
+        }
+
         user.updateNotificationEnabled(enabled);
     }
 
@@ -125,6 +136,16 @@ public class UserCommandService {
     public void updateLocationConsent(Long userId, Boolean consented) {
         User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
                 .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        // 1️. INACTIVE 유저 차단
+        if (user.getStatus() == UserStatus.INACTIVE) {
+            throw new UserException(UserErrorCode.INACTIVE_USER);
+        }
+
+        // 2️. 동일 상태 요청 방어
+        if (user.getLocationConsent().equals(consented)) {
+            return;
+        }
 
         user.updateLocationConsent(consented);
     }

--- a/src/main/java/com/umc/barkit/global/apiPayload/code/GeneralErrorCode.java
+++ b/src/main/java/com/umc/barkit/global/apiPayload/code/GeneralErrorCode.java
@@ -37,7 +37,10 @@ public enum GeneralErrorCode implements BaseErrorCode {
     MEMBERSHIP4005(HttpStatus.CONFLICT, "MEMBERSHIP4005", "이미 저장된 멤버십 브랜드입니다."),
 
     // ========== 바코드 에러 (BARCODE) ==========
-    BARCODE4001(HttpStatus.BAD_REQUEST, "BARCODE4001", "지원하지 않는 바코드 형식입니다.");
+    BARCODE4001(HttpStatus.BAD_REQUEST, "BARCODE4001", "지원하지 않는 바코드 형식입니다."),
+
+    // ========== 홈 에러 (HOME) ==========
+    HOME4001(HttpStatus.INTERNAL_SERVER_ERROR, "HOME4001", "홈 데이터를 조회하는 중 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## #️⃣ 기능 설명
> 멤버십 기준 매장 조회 API 및 알림/위치 권한 설정 API의 예외 처리 정합성 개선

## 🛠️ 작업 상세 내용
- [x] /api/user-membership-brands/{id}/stores 에러코드 정합성 수정
- 존재하지 않는 멤버십 조회 시 MEMBERSHIP4004 사용
- 타인 멤버십 접근 시 MEMBERSHIP4005 사용
- 잘못 매핑되어 있던 에러코드(4001, 4003) 교체
- [x] 알림/위치 권한 설정 API 보완
- INACTIVE 사용자 접근 차단 (INACTIVE_USER)
- 동일 상태 요청 방어 로직 추가
- DTO에 @NotNull 적용하여 null 요청 방지

## 📸 스크린샷 (선택)
/api/user-membership-brands/{id}/stores 에러코드 부분만 swagger 테스트 올렸습니다. 나머지는 DB 정합성 보안
1. 본인 멤버십 외 조회
<img width="1429" height="1853" alt="image" src="https://github.com/user-attachments/assets/89e469af-4b4a-4c67-96d4-50f861ab49cd" />
2.  존재하지 않는 멤버십
<img width="1327" height="1867" alt="image" src="https://github.com/user-attachments/assets/16d35fa8-c46d-4c62-a5f4-e1f2b640d93a" />
3. 정상조회
<img width="1949" height="858" alt="image" src="https://github.com/user-attachments/assets/2d749224-5c3c-43a4-8908-f1e4c4eab0a8" />


## 💬 기타(공유사항 to 리뷰어)