### PR TITLE
[Refactor] 멤버십 기준 매장 조회 API size 상한(50) 제한 추가

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/service/UserMembershipBrandQueryServiceImpl.java
@@ -110,7 +110,12 @@ public class UserMembershipBrandQueryServiceImpl implements UserMembershipBrandQ
             Long cursor,
             Integer size
     ) {
-        int pageSize = (size == null || size <= 0) ? 20 : size;
+
+        int pageSize = 20; // 기본값
+
+        if (size != null && size > 0) {
+            pageSize = Math.min(size, 50); // 최대 50 제한
+        }
 
         // 1. 사용자 멤버십 검증
         UserMembershipBrand umb =


### PR DESCRIPTION
## #️⃣ 기능 설명
> 멤버십 기준 적립/할인 가능 매장 조회 API의 페이징 안정성을 개선했습니다.

## 🛠️ 작업 상세 내용
- [x] size 파라미터 기본값 20 유지
- [x] size 최대 50으로 상한 제한 추가 (Math.min(size, 50))
- [x] 과도한 size 요청에 대한 서버 안정성 방어 로직 적용
- [x] 기존 로직은 그대로 유지

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
- 과도한 size 요청(예: 1000 이상)으로 인한 서버 부하 가능성을 방지하기 위해 상한 제한을 추가했습니다.