### PR TITLE
[Feat] 현재 비밀번호 검증 API 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserController.java
@@ -84,6 +84,16 @@ public class UserController implements UserControllerDocs{
         return ApiResponse.onSuccess(UserSuccessCode.BIRTH_DATE_UPDATED, response);
     }
 
+    // 현재 비밀번호 검증 API
+    @PostMapping("/users/me/validate-password")
+    public ApiResponse<Void> validatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserRequestDto.ValidatePasswordRequestDto request
+    ) {
+        userCommandService.validateCurrentPassword(userDetails.getUserId(), request);
+        return ApiResponse.onSuccess(UserSuccessCode.PASSWORD_VALIDATED, null);
+    }
+
     // 비밀번호 변경 API
     @PatchMapping("/users/me/password")
     public ApiResponse<Void> updatePassword(

--- a/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
+++ b/src/main/java/com/umc/barkit/domain/user/controller/UserControllerDocs.java
@@ -76,6 +76,18 @@ public interface UserControllerDocs {
             @Valid @RequestBody UserRequestDto.UpdateBirthDateRequestDto request
     );
 
+    @Operation(
+            summary = "현재 비밀번호 검증 API",
+            description = "사용자가 입력한 현재 비밀번호를 검증하여 비밀번호 변경을 진행할 수 있도록 합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "비밀번호 검증 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "비밀번호 검증 실패")
+    })
+    ApiResponse<Void> validatePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserRequestDto.ValidatePasswordRequestDto request
+    );
 
     @Operation(
             summary = "비밀번호 변경 API",

--- a/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
+++ b/src/main/java/com/umc/barkit/domain/user/dto/req/UserRequestDto.java
@@ -65,6 +65,12 @@ public class UserRequestDto {
     ) {
     }
 
+    // 현재 비밀번호 검증
+    public record ValidatePasswordRequestDto(
+            @NotNull
+            String currentPassword
+    ){}
+
     // 비밀번호 변경
     public record UpdatePasswordRequestDto(
             @NotNull

--- a/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
+++ b/src/main/java/com/umc/barkit/domain/user/exception/code/UserSuccessCode.java
@@ -18,7 +18,8 @@ public enum UserSuccessCode implements BaseSuccessCode {
 
     PERSONAL_INFO_OK(HttpStatus.OK, "USER2000", "개인정보 조회에 성공했습니다."),
     BIRTH_DATE_UPDATED(HttpStatus.OK, "USER2001", "생년월일 변경에 성공했습니다."),
-    PASSWORD_UPDATED(HttpStatus.OK, "USER2002", "비밀번호 변경에 성공했습니다."),
+    PASSWORD_VALIDATED(HttpStatus.OK, "USER2002","현재 비밀번호가 성공적으로 검증되었습니다."),
+    PASSWORD_UPDATED(HttpStatus.OK, "USER2003", "비밀번호 변경에 성공했습니다."),
 
     NOTIFICATION_UPDATED(HttpStatus.OK, "USER2005", "알림 설정이 변경되었습니다."),
     LOCATION_CONSENT_UPDATED(HttpStatus.OK, "USER2006", "위치 권한 동의 상태가 변경되었습니다."),

--- a/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
+++ b/src/main/java/com/umc/barkit/domain/user/service/command/UserCommandService.java
@@ -79,6 +79,20 @@ public class UserCommandService {
         user.updateBirthDate(birthDate);
     }
 
+    // 현재 비밀번호 검증
+    @Transactional
+    public void validateCurrentPassword(Long userId, UserRequestDto.ValidatePasswordRequestDto request) {
+        // 사용자 조회
+        User user = userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new UserException(UserErrorCode.NOT_FOUND));
+
+        // 현재 비밀번호와 입력한 비밀번호 비교
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPasswordHash())) {
+            throw new UserException(UserErrorCode.INVALID_CURRENT_PASSWORD); // 비밀번호 불일치 시 예외 처리
+        }
+    }
+
+
     // 비밀번호 변경
     @Transactional
     public void updatePassword(Long userId, UserRequestDto.UpdatePasswordRequestDto request){


### PR DESCRIPTION
## #️⃣ 기능 설명
현재 비밀번호 검증 API

## 🛠️ 작업 상세 내용
- [x] 현재 비밀번호 검증 API 구현

## 📸 스크린샷 (선택)
1. 로그인
<img width="907" height="796" alt="image" src="https://github.com/user-attachments/assets/843d415b-1300-450f-9342-83e8e42283e0" />
<img width="453" height="232" alt="image" src="https://github.com/user-attachments/assets/905929f4-a3aa-42ea-9fa3-3c6500f26079" />

2. 현재 비밀번호 검증
* 검증 성공
<img width="907" height="812" alt="image" src="https://github.com/user-attachments/assets/62b5ce9c-6e54-41ac-8baf-7221aa265039" />
<img width="540" height="153" alt="image" src="https://github.com/user-attachments/assets/27b8e092-cedb-46fb-9268-dd87ea740562" />

* 검증 실패
<img width="908" height="490" alt="image" src="https://github.com/user-attachments/assets/ec78bc02-add1-4dde-a11a-141701c4efb5" />
<img width="508" height="183" alt="image" src="https://github.com/user-attachments/assets/a6eb9d01-d92f-4ee5-86f0-37c984af210e" />


## 💬 기타(공유사항 to 리뷰어)