### PR TITLE
♻️ [refactor] StoreBrand, MembershipBrand logoUrl 칼럼 타입 변경

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/entity/MembershipBrand.java
+++ b/src/main/java/com/umc/barkit/domain/membership/entity/MembershipBrand.java
@@ -22,7 +22,7 @@ public class MembershipBrand extends BaseEntity {
     @Column(name = "logo_url", length = 255)
     private String logoUrl;
 
-    @Column(name = "color", length = 10)
+    @Column(name = "color", columnDefinition = "TEXT")
     private String color;
 
 }

--- a/src/main/java/com/umc/barkit/domain/membership/entity/MembershipBrand.java
+++ b/src/main/java/com/umc/barkit/domain/membership/entity/MembershipBrand.java
@@ -19,10 +19,10 @@ public class MembershipBrand extends BaseEntity {
     @Column(name = "name", nullable = false, length = 100)
     private String name;
 
-    @Column(name = "logo_url", length = 255)
+    @Column(name = "logo_url", columnDefinition = "TEXT")
     private String logoUrl;
 
-    @Column(name = "color", columnDefinition = "TEXT")
+    @Column(name = "color", length = 10)
     private String color;
 
 }

--- a/src/main/java/com/umc/barkit/domain/store/entity/StoreBrand.java
+++ b/src/main/java/com/umc/barkit/domain/store/entity/StoreBrand.java
@@ -27,6 +27,6 @@ public class StoreBrand extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Category category;
 
-    @Column(name = "logo_url", length = 255)
+    @Column(name = "logo_url", columnDefinition = "TEXT")
     private String logoUrl;
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> StoreBrand, MembershipBrand logoUrl 칼럼 타입을 text로 변경

## 🛠️ 작업 상세 내용
- [x] `StoreBrand`, `MembershipBrand`엔티티의 logoUrl 필드 `@column`에서 `length = 255` 제거 후 `columnDefinition = "TEXT"` 추가


## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)