### PR TITLE
♻️ [Refactor] 멤버십 상세 조회 시 적립/할인 가능 매장 인기순 정렬 구현

### DIFF
--- a/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
+++ b/src/main/java/com/umc/barkit/domain/membership/repository/UserMembershipBrandRepositoryImpl.java
@@ -109,7 +109,7 @@ public class UserMembershipBrandRepositoryImpl implements UserMembershipBrandRep
                 .join(storeBrandMembershipBrand)
                 .on(storeBrandMembershipBrand.storeBrand.eq(storeBrand))
                 .where(storeBrandMembershipBrand.membershipBrand.id.eq(membershipBrandId))
-                .orderBy(storeBrand.id.asc())
+                .orderBy(storeBrandMembershipBrand.popularityRank.asc())
                 .fetch();
     }
 


### PR DESCRIPTION
## #️⃣ 기능 설명
> 멤버십 상세 조회 시 적립/할인 가능한 매장 브랜드 목록을 인기순으로 정렬하여 반환하도록 수정

## 🛠️ 작업 상세 내용
- [x] StoreBrandMembershipBrand 엔티티에 popularityRank 컬럼 추가(Long 타입)
- [x] 멤버십 브랜드별 매장 인기 순위 데이터 DB 저장 
- [x] findStoreBrandsByMembershipBrandId 쿼리 정렬 기준 변경
- [x] 기존 storeBrand.id.asc() → storeBrandMembershipBrand.popularityRank.asc()로 수정
- [x] CJ ONE, 롯데, 신한, 해피포인트 등 주요 멤버십 브랜드의 매장 인기 순위 데이터 입력

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)